### PR TITLE
send_one.py: set all bits in ethernet header to 0

### DIFF
--- a/examples/copy_to_cpu/send_one.py
+++ b/examples/copy_to_cpu/send_one.py
@@ -1,6 +1,6 @@
 from scapy.all import *
 
-p = Ether(dst="aa:bb:cc:dd:ee:ff") / IP(dst="10.0.1.10") / TCP() / "aaaaaaaaaaaaaaaaaaa"
-# p.show()
+p = Ether(dst="00:00:00:00:00:00", src="00:00:00:00:00:00", type=0x0) / IP(dst="10.0.1.10") / TCP() / "aaaaaaaaaaaaaaaaaaa"
+p.show()
 hexdump(p)
 sendp(p, iface = "veth1")


### PR DESCRIPTION
Hi Antonin,

Maybe, you forget to change the ethernet header when sending packet in send_one.py script. The sender in the current example does not set all bits in ethernet header to 0. Therefore, the example does not show the copy_to_cpu effect. My change reflects the do_copy_to_cpu action as the receiver observes the modified header.