### PR TITLE
Explicitly import Popen and PIPE form subprocess

### DIFF
--- a/examples/simple_nat/nat_app.py
+++ b/examples/simple_nat/nat_app.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from scapy.all import *
-import subprocess
+from subprocess import Popen, PIPE
 import os
 
 CLI_PATH = None


### PR DESCRIPTION
The code will terminate with "NameError: global name 'Popen' (PIPE) is not defined" without importing Popen and PIPE explicitly.

I've tested the proposed change using Python 2.7.12 on Ubuntu 16.04.02.