### PR TITLE
Updating check_switch_started in p4runtime_switch.py

### DIFF
--- a/P4D2_2017_Fall/exercises/p4runtime/README.md
+++ b/P4D2_2017_Fall/exercises/p4runtime/README.md
@@ -5,7 +5,7 @@
 In this exercise, we will be using P4 Runtime to send flow entries to the 
 switch instead of using the switch's CLI. We will be building on the same P4
 program that you used in the [basic_tunnel](../basic_tunnel) exercise. The
-P4 program has be renamed to `advanced_tunnel.py` and has been augmented
+P4 program has been renamed to `advanced_tunnel.py` and has been augmented
 with two counters (`ingressTunnelCounter`, `egressTunnelCounter`) and
 two new actions (`myTunnel_ingress`, `myTunnel_egress`).
  
@@ -20,7 +20,7 @@ necessary to tunnel traffic between host 1 and 2.
 ## Step 1: Run the (incomplete) starter code
 
 The starter code for this assignment is in a file called `mycontroller.py`,
-and it will install only some of the rules that you need tunnel traffic between
+and it will install only some of the rules that you need to tunnel traffic between
 two hosts.
 
 Let's first compile the new P4 program, start the network, use `mycontroller.py`

--- a/P4D2_2017_Fall/exercises/p4runtime/mycontroller.py
+++ b/P4D2_2017_Fall/exercises/p4runtime/mycontroller.py
@@ -43,13 +43,19 @@ def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
 
     # 2) Tunnel Transit Rule
     # The rule will need to be added to the myTunnel_exact table and match on
-    # the tunnel ID (hdr.myTunnel.dst_id). For our simple topology, transit
-    # traffic will need to be forwarded on the using the myTunnel_forward action
-    # on the SWITCH_TO_SWITCH_PORT (port 2).
+    # the tunnel ID (hdr.myTunnel.dst_id). Traffic will need to be forwarded
+    # using the myTunnel_forward action on the port connected to the next switch.
     #
-    # We will only need on transit rule on the ingress switch because we are
+    # For our simple topology, switch 1 and switch 2 are connected using a
+    # link attached to port 2 on both switches. We have defined a variable at
+    # the top of the file, SWITCH_TO_SWITCH_PORT, that you can use as the output
+    # port for this action.
+    #
+    # We will only need a transit rule on the ingress switch because we are
     # using a simple topology. In general, you'll need on transit rule for
-    # each switch in the path (except the last one).
+    # each switch in the path (except the last switch, which has the egress rule),
+    # and you will need to select the port dynamically for each switch based on
+    # your topology.
 
     # TODO build the transit rule
     # TODO install the transit rule on the ingress switch

--- a/P4D2_2017_Fall/exercises/p4runtime/solution/mycontroller.py
+++ b/P4D2_2017_Fall/exercises/p4runtime/solution/mycontroller.py
@@ -48,13 +48,20 @@ def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
 
     # 2) Tunnel Transit Rule
     # The rule will need to be added to the myTunnel_exact table and match on
-    # the tunnel ID (hdr.myTunnel.dst_id). For our simple topology, transit
-    # traffic will need to be forwarded on the using the myTunnel_forward action
-    # on the SWITCH_TO_SWITCH_PORT (port 2).
+    # the tunnel ID (hdr.myTunnel.dst_id). Traffic will need to be forwarded
+    # using the myTunnel_forward action on the port connected to the next switch.
     #
-    # We will only need on transit rule on the ingress switch because we are
+    # For our simple topology, switch 1 and switch 2 are connected using a
+    # link attached to port 2 on both switches. We have defined a variable at
+    # the top of the file, SWITCH_TO_SWITCH_PORT, that you can use as the output
+    # port for this action.
+    #
+    # We will only need a transit rule on the ingress switch because we are
     # using a simple topology. In general, you'll need on transit rule for
-    # each switch in the path (except the last one).
+    # each switch in the path (except the last switch, which has the egress rule),
+    # and you will need to select the port dynamically for each switch based on
+    # your topology.
+
     table_entry = p4info_helper.buildTableEntry(
         table_name="myTunnel_exact",
         match_fields={


### PR DESCRIPTION
The previous implementation had a race conditiona between the
socket check and the BMv2 startup. Sometimes, if the check happen
just before (or as) BMv2 was trying to bind the port, it would
not be able to bind it. This solution uses psutil's equivalent
to 'netstat' to determine whether is BMv2 has bound the port yet.