### PR TITLE
Fixed the build for basic.p4.

### DIFF
--- a/SIGCOMM_2017/exercises/basic/basic.p4
+++ b/SIGCOMM_2017/exercises/basic/basic.p4
@@ -62,7 +62,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(in headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 


### PR DESCRIPTION
basic.p4 fails to build out of the box. This appears to fix it.
```
p4@p4:~/tutorials/SIGCOMM_2017/exercises/basic$ ./run.sh 
Entering build directory.
Extracting package.
Reading package manifest.
> p4c-bm2-ss --p4v 16 "basic.p4" -o "basic.p4.json"
basic.p4(160): error: main: Cannot unify parameter hdr with hdr because they have different directions
) main;
  ^^^^
basic.p4(65)
control MyVerifyChecksum(in headers hdr, inout metadata meta) {
                                    ^^^
/usr/local/share/p4c/p4include/v1model.p4(197)
control VerifyChecksum<H, M>(inout H hdr,
                                     ^^^
Compile failed.
```