### PR TITLE
Updated the clone URL of mininet

### DIFF
--- a/P4D2_2017_Fall/vm/user-bootstrap.sh
+++ b/P4D2_2017_Fall/vm/user-bootstrap.sh
@@ -14,7 +14,7 @@ GRPC_COMMIT="tags/v1.3.0"
 NUM_CORES=`grep -c ^processor /proc/cpuinfo`
 
 # Mininet
-git clone git://github.com/mininet/mininet mininet
+git clone https://github.com/mininet/mininet.git
 cd mininet
 sudo ./util/install.sh -nwv
 cd ..

--- a/P4D2_2017_Fall/vm/user-bootstrap.sh
+++ b/P4D2_2017_Fall/vm/user-bootstrap.sh
@@ -126,7 +126,7 @@ cd .vim
 mkdir ftdetect
 mkdir syntax
 echo "au BufRead,BufNewFile *.p4      set filetype=p4" >> ftdetect/p4.vim
-echo "set bg=dark" >> /home/p4/.vimrc
+echo "set bg=dark" | sudo tee --append /home/p4/.vimrc
 cp /home/vagrant/p4.vim syntax/p4.vim
 cd /home/vagrant
 sudo mv .vim /home/p4/.vim


### PR DESCRIPTION
Cloning a repository through SSH sometimes fails.
Especially, when the vm is new and the SSH key hasn't be created.

And I tried to run the script and it failed when cloning the repository.
(error message: "connection reset by peer")

And I ran the script successfully with the same environment except cloning through HTTPS.
So, I think it's more safe to clone the repository through HTTPS.

And there's a permission error in user-bootstrap.