### PR TITLE
Fix MRI exercise solutions for recent bmv2 versions

### DIFF
--- a/P4D2_2017_Fall/exercises/mri/solution/mri.p4
+++ b/P4D2_2017_Fall/exercises/mri/solution/mri.p4
@@ -193,6 +193,11 @@ control MyEgress(inout headers hdr,
     action add_swtrace(switchID_t swid) { 
         hdr.mri.count = hdr.mri.count + 1;
         hdr.swtraces.push_front(1);
+        // According to the P4_16 spec, pushed elements are invalid, so we need
+        // to call setValid(). Older bmv2 versions would mark the new header(s)
+        // valid automatically (P4_14 behavior), but starting with version 1.11,
+        // bmv2 conforms with the P4_16 spec.
+        hdr.swtraces[0].setValid();
         hdr.swtraces[0].swid = swid;
         hdr.swtraces[0].qdepth = (qdepth_t)standard_metadata.deq_qdepth;
 

--- a/P4D2_2017_Spring/exercises/mri/solution/mri.p4
+++ b/P4D2_2017_Spring/exercises/mri/solution/mri.p4
@@ -167,6 +167,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     action add_swid(switchID_t id) {    
         hdr.mri.count = hdr.mri.count + 1;
         hdr.swids.push_front(1);
+        // According to the P4_16 spec, pushed elements are invalid, so we need
+        // to call setValid(). Older bmv2 versions would mark the new header(s)
+        // valid automatically (P4_14 behavior), but starting with version 1.11,
+        // bmv2 conforms with the P4_16 spec.
+        hdr.swids[0].setValid();
         hdr.swids[0].swid = id;
 
         hdr.ipv4.ihl = hdr.ipv4.ihl + 1;

--- a/P4D2_2018_East/exercises/mri/solution/mri.p4
+++ b/P4D2_2018_East/exercises/mri/solution/mri.p4
@@ -193,6 +193,11 @@ control MyEgress(inout headers hdr,
     action add_swtrace(switchID_t swid) { 
         hdr.mri.count = hdr.mri.count + 1;
         hdr.swtraces.push_front(1);
+        // According to the P4_16 spec, pushed elements are invalid, so we need
+        // to call setValid(). Older bmv2 versions would mark the new header(s)
+        // valid automatically (P4_14 behavior), but starting with version 1.11,
+        // bmv2 conforms with the P4_16 spec.
+        hdr.swtraces[0].setValid();
         hdr.swtraces[0].swid = swid;
         hdr.swtraces[0].qdepth = (qdepth_t)standard_metadata.deq_qdepth;
 

--- a/SIGCOMM_2017/exercises/mri/solution/mri.p4
+++ b/SIGCOMM_2017/exercises/mri/solution/mri.p4
@@ -193,6 +193,11 @@ control MyEgress(inout headers hdr,
     action add_swtrace(switchID_t swid) { 
         hdr.mri.count = hdr.mri.count + 1;
         hdr.swtraces.push_front(1);
+        // According to the P4_16 spec, pushed elements are invalid, so we need
+        // to call setValid(). Older bmv2 versions would mark the new header(s)
+        // valid automatically (P4_14 behavior), but starting with version 1.11,
+        // bmv2 conforms with the P4_16 spec.
+        hdr.swtraces[0].setValid();
         hdr.swtraces[0].swid = swid;
         hdr.swtraces[0].qdepth = (qdepth_t)standard_metadata.deq_qdepth;
 


### PR DESCRIPTION
Starting with version 1.11, bmv2 conforms with the P4_16 spec and
push_front no longer marks new headers as valid. With this commit, we
add calls to setValid after calls to push_front. For people using older
bmv2 versions, this means that the new header will be marked valid twice
in a row, which should not be an issue.

Fixes #132 