### PR TITLE
p4runtime lib: wait for MasterArbitrationUpdate to complete

### DIFF
--- a/utils/p4runtime_lib/switch.py
+++ b/utils/p4runtime_lib/switch.py
@@ -65,6 +65,8 @@ class SwitchConnection(object):
             print "P4Runtime MasterArbitrationUpdate: ", request
         else:
             self.requests_stream.put(request)
+            for item in self.stream_msg_resp:
+                return item # just one
 
     def SetForwardingPipelineConfig(self, p4info, dry_run=False, **kwargs):
         device_config = self.buildDeviceConfig(**kwargs)


### PR DESCRIPTION
Running the exercises can race:

	$ make run
	mkdir -p build pcaps logs
	p4c-bm2-ss --p4v 16 --p4runtime-file build/basic.p4info --p4runtime-format text -o build/basic.json basic.p4
	sudo python ../../utils/run_exercise.py -t topology.json -b simple_switch_grpc
	Reading topology file.
	Building mininet topology.
	Switch port mapping:
	s1:  1:h1	2:s2	3:s3
	s2:  1:h2	2:s1	3:s3
	s3:  1:h3	2:s1	3:s2
	Configuring switch s3 using P4Runtime with file s3-runtime.json
	 - Using P4Info file build/basic.p4info...
	 - Connecting to P4Runtime server on 127.0.0.1:50053 (bmv2)...
	 - Setting pipeline config (build/basic.json)...
	Traceback (most recent call last):
	  File "../../utils/run_exercise.py", line 408, in <module>
	    exercise.run_exercise()
	  File "../../utils/run_exercise.py", line 207, in run_exercise
	    self.program_switches()
	  File "../../utils/run_exercise.py", line 312, in program_switches
	    self.program_switch_p4runtime(sw_name, sw_dict)
	  File "../../utils/run_exercise.py", line 284, in program_switch_p4runtime
	    proto_dump_fpath=outfile)
	  File "/home/p4/tutorials/utils/p4runtime_lib/simple_controller.py", line 120, in program_switch
	    bmv2_json_file_path=bmv2_json_fpath)
	  File "/home/p4/tutorials/utils/p4runtime_lib/switch.py", line 85, in SetForwardingPipelineConfig
	    self.client_stub.SetForwardingPipelineConfig(request)
	  File "/usr/local/lib/python2.7/dist-packages/grpc/_interceptor.py", line 141, in __call__
	    return call_future.result()
	  File "/usr/local/lib/python2.7/dist-packages/grpc/_channel.py", line 272, in result
	    raise self
	grpc._channel._Rendezvous: <_Rendezvous of RPC that terminated with (StatusCode.PERMISSION_DENIED, Not master)>
	../../utils/Makefile:27: recipe for target 'run' failed
	make: *** [run] Error 1

Fix that by waiting for one response after sending MasterArbitrationUpdate.

Signed-off-by: Alex Badea <alex.badea@keysight.com>