### PR TITLE
Changed vagrant box from fso to lasp

### DIFF
--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "fso/xenial64-desktop"
+  config.vm.box = "lasp/ubuntu16.04-desktop"
   config.vm.define "p4-tutorial" do |tutorial|
   end
   config.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
I found that the old fso box is no longer maintained and has been deprecated on Oct 8th as explained in [this post](https://app.vagrantup.com/fso/boxes/xenial64-desktop/versions/2018.10.08.0). The authors suggest to migrate to lasp box.

This PR solves the issue of vagrant up breakage as reported in issue #204.