### PR TITLE
Changed the location of lightdm config to fix default user setting breakage

### DIFF
--- a/vm/root-bootstrap.sh
+++ b/vm/root-bootstrap.sh
@@ -83,7 +83,7 @@ sed -i s@#background=@background=/usr/share/lubuntu/wallpapers/1604-lubuntu-defa
 apt-get -y remove light-locker
 
 # Automatically log into the P4 user
-cat << EOF | tee -a /etc/lightdm/lightdm.conf.d/10-lightdm.conf
+cat << EOF | tee /etc/lightdm/lightdm.conf
 [SeatDefaults]
 autologin-user=p4
 autologin-user-timeout=0


### PR DESCRIPTION
After testing the result of PR #206 (migrating the vagrant box from the deprecated fso box to lasp box), I discovered that the root-bootstrap script does not succeed in making the `p4` user as the default user for the GUI.

This is caused by the difference in lightdm config locations. The old fso box holds the config in `/etc/lightdm/lightdm.conf.d/10-lightdm.conf` while the new lasp box holds the config in `/etc/lightdm/lightdm.conf`.

This PR attempts to fix that issue.

Tested and worked:
```
$ vagrant up
    ...<redacted for clarity>...
    p4-tutorial-test: Rebuilding /usr/share/applications/bamf-2.index...
    p4-tutorial-test: Processing triggers for mime-support (3.59ubuntu1) ...
    p4-tutorial-test: Processing triggers for libglib2.0-0:amd64 (2.48.2-0ubuntu4.1) ...
    p4-tutorial-test: Processing triggers for man-db (2.7.5-1) ...
    p4-tutorial-test: + cat
    p4-tutorial-test: + tee /etc/lightdm/lightdm.conf
    p4-tutorial-test: [SeatDefaults]
    p4-tutorial-test: autologin-user=p4
    p4-tutorial-test: autologin-user-timeout=0
    p4-tutorial-test: user-session=Lubuntu
```

The machine now boots up with `p4` as the default user.