### PR TITLE
Update README for basic and basic_tunnel p4app-exercises

### DIFF
--- a/p4app-exercises/basic.p4app/main.py
+++ b/p4app-exercises/basic.p4app/main.py
@@ -5,7 +5,11 @@ from mininet.cli import CLI
 
 if len(sys.argv) > 1:
     if sys.argv[1] == 'compile':
-        P4Program('basic.p4').compile()
+        try:
+            P4Program('basic.p4').compile()
+        except Exception as e:
+            print(e)
+            sys.exit(1)
         sys.exit(0)
 
 N = 3
@@ -34,7 +38,11 @@ class RingTopo(Topo):
             self.addLink(switches[i], switches[(i+1)%n], port1=2, port2=3)
 
 topo = RingTopo(N)
-net = P4Mininet(program='basic.p4', topo=topo)
+try:
+    net = P4Mininet(program='basic.p4', topo=topo)
+except Exception as e:
+    print(e)
+    sys.exit(1)
 net.start()
 
 for i in range(1, N+1):

--- a/p4app-exercises/basic_tunnel.p4app/main.py
+++ b/p4app-exercises/basic_tunnel.p4app/main.py
@@ -5,7 +5,11 @@ from mininet.cli import CLI
 
 if len(sys.argv) > 1:
     if sys.argv[1] == 'compile':
-        P4Program('basic_tunnel.p4').compile()
+        try:
+            P4Program('basic_tunnel.p4').compile()
+        except Exception as e:
+            print(e)
+            sys.exit(1)
         sys.exit(0)
 
 N = 3
@@ -34,7 +38,11 @@ class RingTopo(Topo):
             self.addLink(switches[i], switches[(i+1)%n], port1=2, port2=3)
 
 topo = RingTopo(N)
-net = P4Mininet(program='basic_tunnel.p4', topo=topo)
+try:
+    net = P4Mininet(program='basic_tunnel.p4', topo=topo)
+except Exception as e:
+    print(e)
+    sys.exit(1)
 net.start()
 
 for i in range(1, N+1):


### PR DESCRIPTION
There were changes made to IPv4 addresses assigned to hosts, and many
small changes to the instructions.

Also wrapped Python calls that compile the user's program with
try/except so that the compiler error messages are less likely
to scroll off the screen due to a Python stack trace.