### PR TITLE
This is one way to fix the solution to the p4runtime.p4app exercise

### DIFF
--- a/p4app-exercises/p4runtime.p4app/mycontroller.py
+++ b/p4app-exercises/p4runtime.p4app/mycontroller.py
@@ -18,7 +18,7 @@ import p4runtime_lib.helper
 SWITCH_TO_HOST_PORT = 1
 
 def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
-                     dst_eth_addr, dst_ip_addr, port):
+                     dst_eth_addr, dst_ip_addr, ingress_sw_port):
     """
     Installs three rules:
     1) An tunnel ingress rule on the ingress switch in the ipv4_lpm table that
@@ -57,7 +57,7 @@ def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
     # For our simple topology, the link from switch 1 to switch 2 is
     # numbered port 2 on switch 1 (clockwise around the ring), but
     # numbered port 3 on switch 2 (counterclockwise around the ring).
-    # Use the parameter 'port' to specify which output port the
+    # Use the parameter 'ingress_sw_port' to specify which output port the
     # traffic should be sent next.
     #
     # We will only need a transit rule on the ingress switch because we are
@@ -160,12 +160,12 @@ def main(p4info_file_path, bmv2_file_path):
         # Write the rules that tunnel traffic from h1 to h2
         writeTunnelRules(p4info_helper, ingress_sw=s1, egress_sw=s2, tunnel_id=100,
                          dst_eth_addr="00:00:00:00:02:02", dst_ip_addr="10.0.2.2",
-                         port=2)
+                         ingress_sw_port=2)
 
         # Write the rules that tunnel traffic from h2 to h1
         writeTunnelRules(p4info_helper, ingress_sw=s2, egress_sw=s1, tunnel_id=200,
                          dst_eth_addr="00:00:00:00:01:01", dst_ip_addr="10.0.1.1",
-                         port=3)
+                         ingress_sw_port=3)
 
         # TODO Uncomment the following two lines to read table entries from s1 and s2
         # readTableRules(p4info_helper, s1)

--- a/p4app-exercises/p4runtime.p4app/mycontroller.py
+++ b/p4app-exercises/p4runtime.p4app/mycontroller.py
@@ -16,10 +16,9 @@ from p4runtime_lib.switch import ShutdownAllSwitchConnections
 import p4runtime_lib.helper
 
 SWITCH_TO_HOST_PORT = 1
-SWITCH_TO_SWITCH_PORT = 2
 
 def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
-                     dst_eth_addr, dst_ip_addr):
+                     dst_eth_addr, dst_ip_addr, port):
     """
     Installs three rules:
     1) An tunnel ingress rule on the ingress switch in the ipv4_lpm table that
@@ -55,10 +54,11 @@ def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
     # the tunnel ID (hdr.myTunnel.dst_id). Traffic will need to be forwarded
     # using the myTunnel_forward action on the port connected to the next switch.
     #
-    # For our simple topology, switch 1 and switch 2 are connected using a
-    # link attached to port 2 on both switches. We have defined a variable at
-    # the top of the file, SWITCH_TO_SWITCH_PORT, that you can use as the output
-    # port for this action.
+    # For our simple topology, the link from switch 1 to switch 2 is
+    # numbered port 2 on switch 1 (clockwise around the ring), but
+    # numbered port 3 on switch 2 (counterclockwise around the ring).
+    # Use the parameter 'port' to specify which output port the
+    # traffic should be sent next.
     #
     # We will only need a transit rule on the ingress switch because we are
     # using a simple topology. In general, you'll need on transit rule for
@@ -159,11 +159,13 @@ def main(p4info_file_path, bmv2_file_path):
 
         # Write the rules that tunnel traffic from h1 to h2
         writeTunnelRules(p4info_helper, ingress_sw=s1, egress_sw=s2, tunnel_id=100,
-                         dst_eth_addr="00:00:00:00:02:02", dst_ip_addr="10.0.2.2")
+                         dst_eth_addr="00:00:00:00:02:02", dst_ip_addr="10.0.2.2",
+                         port=2)
 
         # Write the rules that tunnel traffic from h2 to h1
         writeTunnelRules(p4info_helper, ingress_sw=s2, egress_sw=s1, tunnel_id=200,
-                         dst_eth_addr="00:00:00:00:01:01", dst_ip_addr="10.0.1.1")
+                         dst_eth_addr="00:00:00:00:01:01", dst_ip_addr="10.0.1.1",
+                         port=3)
 
         # TODO Uncomment the following two lines to read table entries from s1 and s2
         # readTableRules(p4info_helper, s1)

--- a/p4app-exercises/p4runtime.p4app/solution/mycontroller.py
+++ b/p4app-exercises/p4runtime.p4app/solution/mycontroller.py
@@ -16,10 +16,11 @@ from p4runtime_lib.switch import ShutdownAllSwitchConnections
 import p4runtime_lib.helper
 
 SWITCH_TO_HOST_PORT = 1
-SWITCH_TO_SWITCH_PORT = 2
+CLOCKWISE_SWITCH_TO_SWITCH_PORT = 2
+COUNTERCLOCKWISE_SWITCH_TO_SWITCH_PORT = 3
 
 def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
-                     dst_eth_addr, dst_ip_addr):
+                     dst_eth_addr, dst_ip_addr, direction):
     """
     Installs three rules:
     1) An tunnel ingress rule on the ingress switch in the ipv4_lpm table that
@@ -55,10 +56,16 @@ def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
     # the tunnel ID (hdr.myTunnel.dst_id). Traffic will need to be forwarded
     # using the myTunnel_forward action on the port connected to the next switch.
     #
-    # For our simple topology, switch 1 and switch 2 are connected using a
-    # link attached to port 2 on both switches. We have defined a variable at
-    # the top of the file, SWITCH_TO_SWITCH_PORT, that you can use as the output
-    # port for this action.
+    # For our simple topology, the link from switch 1 to switch 2 is
+    # numbered port 2 on switch 1 (clockwise around the ring), but
+    # numbered port 3 on switch 2 (counterclockwise around the ring).
+    # link attached to port 2 on both switches. We have defined two
+    # variables at the top of the file,
+    # CLOCKWISE_SWITCH_TO_SWITCH_PORT and
+    # COUNTERCLOCKWISE_SWITCH_TO_SWITCH_PORT, that you can use as the
+    # output port for this action, based upon the value of the
+    # 'direction' parameter of this method.
+
     #
     # We will only need a transit rule on the ingress switch because we are
     # using a simple topology. In general, you'll need on transit rule for
@@ -68,6 +75,10 @@ def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
 
     # TODO build the transit rule
     # TODO install the transit rule on the ingress switch
+    if direction == "clockwise":
+        switch_port = CLOCKWISE_SWITCH_TO_SWITCH_PORT
+    else:
+        switch_port = COUNTERCLOCKWISE_SWITCH_TO_SWITCH_PORT
     table_entry = p4info_helper.buildTableEntry(
         table_name="MyIngress.myTunnel_exact",
         match_fields={
@@ -75,7 +86,7 @@ def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
         },
         action_name="MyIngress.myTunnel_forward",
         action_params={
-            "port": SWITCH_TO_SWITCH_PORT
+            "port": switch_port
         })
     ingress_sw.WriteTableEntry(table_entry)
     print "Installed transit tunnel rule on %s" % ingress_sw.name
@@ -178,11 +189,13 @@ def main(p4info_file_path, bmv2_file_path):
 
         # Write the rules that tunnel traffic from h1 to h2
         writeTunnelRules(p4info_helper, ingress_sw=s1, egress_sw=s2, tunnel_id=100,
-                         dst_eth_addr="00:00:00:00:02:02", dst_ip_addr="10.0.2.2")
+                         dst_eth_addr="00:00:00:00:02:02", dst_ip_addr="10.0.2.2",
+                         direction="clockwise")
 
         # Write the rules that tunnel traffic from h2 to h1
         writeTunnelRules(p4info_helper, ingress_sw=s2, egress_sw=s1, tunnel_id=200,
-                         dst_eth_addr="00:00:00:00:01:01", dst_ip_addr="10.0.1.1")
+                         dst_eth_addr="00:00:00:00:01:01", dst_ip_addr="10.0.1.1",
+                         direction="counterclockwise")
 
         # TODO Uncomment the following two lines to read table entries from s1 and s2
         readTableRules(p4info_helper, s1)

--- a/p4app-exercises/p4runtime.p4app/solution/mycontroller.py
+++ b/p4app-exercises/p4runtime.p4app/solution/mycontroller.py
@@ -18,7 +18,7 @@ import p4runtime_lib.helper
 SWITCH_TO_HOST_PORT = 1
 
 def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
-                     dst_eth_addr, dst_ip_addr, port):
+                     dst_eth_addr, dst_ip_addr, ingress_sw_port):
     """
     Installs three rules:
     1) An tunnel ingress rule on the ingress switch in the ipv4_lpm table that
@@ -57,7 +57,7 @@ def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
     # For our simple topology, the link from switch 1 to switch 2 is
     # numbered port 2 on switch 1 (clockwise around the ring), but
     # numbered port 3 on switch 2 (counterclockwise around the ring).
-    # Use the parameter 'port' to specify which output port the
+    # Use the parameter 'ingress_sw_port' to specify which output port the
     # traffic should be sent next.
     #
     # We will only need a transit rule on the ingress switch because we are
@@ -75,7 +75,7 @@ def writeTunnelRules(p4info_helper, ingress_sw, egress_sw, tunnel_id,
         },
         action_name="MyIngress.myTunnel_forward",
         action_params={
-            "port": port
+            "port": ingress_sw_port
         })
     ingress_sw.WriteTableEntry(table_entry)
     print "Installed transit tunnel rule on %s" % ingress_sw.name
@@ -179,12 +179,12 @@ def main(p4info_file_path, bmv2_file_path):
         # Write the rules that tunnel traffic from h1 to h2
         writeTunnelRules(p4info_helper, ingress_sw=s1, egress_sw=s2, tunnel_id=100,
                          dst_eth_addr="00:00:00:00:02:02", dst_ip_addr="10.0.2.2",
-                         port=2)
+                         ingress_sw_port=2)
 
         # Write the rules that tunnel traffic from h2 to h1
         writeTunnelRules(p4info_helper, ingress_sw=s2, egress_sw=s1, tunnel_id=200,
                          dst_eth_addr="00:00:00:00:01:01", dst_ip_addr="10.0.1.1",
-                         port=3)
+                         ingress_sw_port=3)
 
         # TODO Uncomment the following two lines to read table entries from s1 and s2
         readTableRules(p4info_helper, s1)


### PR DESCRIPTION
This PR represents one way to make the solution to p4runtime.p4app correct.  It keeps the ring of 3 switches as shown in the topo.png diagram, and corrects the port numbered in the installed table entries to go the correct way around the ring.

Alternate solutions would be:

+ do not make any changes to solution/mycontroller.py, and go back to using a "ring" of 2 switches for this exercise, the way it was a couple of days ago.  In that case, the topo.png and README.md file should be updated to show the correct topology of 2 switches and 2 hosts.

+ do not make any changes to solution/mycontroller.py, use a ring of 3 switches, but change the switch port numbers used on s2 so that port 2 leads to s1, as it did in the original exercises/p4runtime.

I do not have a strong preference, but do have a mild preference for the changes in this PR, as they do not require changes to the current topo, topo figure, and README instructions, and they only make the student's job slightly more though-provoking, since they need to install different port action parameter values for the different directions of data traffic.