### PR TITLE
Drop unrecognized packets, instead of not doing anything

### DIFF
--- a/p4app-exercises/basic.p4app/README.md
+++ b/p4app-exercises/basic.p4app/README.md
@@ -111,7 +111,8 @@ A complete `basic.p4` will contain the following components:
 5. **TODO:** A control that:
     1. Defines a table that will read an IPv4 destination address, and
        invoke either `drop` or `ipv4_forward`.
-    2. An `apply` block that applies the table.   
+    2. An `apply` block that applies the table for IPv4 packets and drops all
+       other packets.
 6. **TODO:** A deparser that selects the order
     in which fields inserted into the outgoing packet.
 7. A `package` instantiation supplied with the parser, control, and deparser.

--- a/p4app-exercises/basic.p4app/basic.p4
+++ b/p4app-exercises/basic.p4app/basic.p4
@@ -98,6 +98,7 @@ control MyIngress(inout headers hdr,
     apply {
         /* TODO: fix ingress control logic
          *  - ipv4_lpm should be applied only when IPv4 header is valid
+         *  - drop the packet otherwise
          */
         ipv4_lpm.apply();
     }

--- a/p4app-exercises/basic.p4app/main.py
+++ b/p4app-exercises/basic.p4app/main.py
@@ -61,7 +61,7 @@ for i in range(1, N+1):
         sw.insertTableEntry(table_name='MyIngress.ipv4_lpm',
                             match_fields={'hdr.ipv4.dstAddr': ["10.0.0.%d" % j, 32]},
                             action_name='MyIngress.ipv4_forward',
-                            action_params={'dstAddr': '00:00:00:00:00:%02x' % j,
+                            action_params={'dstAddr': '00:00:00:00:ff:%02x' % j,
                                               'port': getForwardingPort(i, j)})
 
 

--- a/p4app-exercises/basic.p4app/solution/basic.p4
+++ b/p4app-exercises/basic.p4app/solution/basic.p4
@@ -113,6 +113,8 @@ control MyIngress(inout headers hdr,
     apply {
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
+        } else {
+            drop();
         }
     }
 }

--- a/p4app-exercises/basic_tunnel.p4app/basic_tunnel.p4
+++ b/p4app-exercises/basic_tunnel.p4app/basic_tunnel.p4
@@ -133,6 +133,8 @@ control MyIngress(inout headers hdr,
         // TODO: Update control flow
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
+        } else {
+            drop();
         }
     }
 }

--- a/p4app-exercises/basic_tunnel.p4app/main.py
+++ b/p4app-exercises/basic_tunnel.p4app/main.py
@@ -65,7 +65,7 @@ for i in range(1, N+1):
         sw.insertTableEntry(table_name='MyIngress.ipv4_lpm',
                             match_fields={'hdr.ipv4.dstAddr': ["10.0.0.%d" % j, 32]},
                             action_name='MyIngress.ipv4_forward',
-                            action_params={'dstAddr': '00:00:00:00:00:%02x' % j,
+                            action_params={'dstAddr': '00:00:00:00:ff:%02x' % j,
                                               'port': getForwardingPort(i, j)})
         sw.insertTableEntry(table_name='MyIngress.myTunnel_exact',
                             match_fields={'hdr.myTunnel.dst_id': [j]},

--- a/p4app-exercises/basic_tunnel.p4app/solution/basic_tunnel.p4
+++ b/p4app-exercises/basic_tunnel.p4app/solution/basic_tunnel.p4
@@ -143,14 +143,15 @@ control MyIngress(inout headers hdr,
     }
 
     apply {
-        if (hdr.ipv4.isValid() && !hdr.myTunnel.isValid()) {
-            // Process only non-tunneled IPv4 packets
-            ipv4_lpm.apply();
-        }
-
-        if (hdr.myTunnel.isValid()) {
+        if (!hdr.ipv4.isValid() && !hdr.myTunnel.isValid()) {
+            // drop non-tunneled, non-IPv4 packets
+            drop();
+        } else if (hdr.myTunnel.isValid()) {
             // process tunneled packets
             myTunnel_exact.apply();
+        } else {
+            // process non-tunneled IPv4 packets
+            ipv4_lpm.apply();
         }
     }
 }

--- a/p4app-exercises/p4runtime.p4app/README.md
+++ b/p4app-exercises/p4runtime.p4app/README.md
@@ -6,7 +6,8 @@ In this exercise, we will be building on the same P4
 program that you used in the [basic_tunnel](../basic_tunnel.p4app) exercise. The
 P4 program has been renamed to `advanced_tunnel.py` and has been augmented
 with two counters (`ingressTunnelCounter`, `egressTunnelCounter`) and
-two new actions (`myTunnel_ingress`, `myTunnel_egress`).
+two new actions (`myTunnel_ingress`, `myTunnel_egress`), which take care of
+performing encap and decap on IPv4 packets using our tunneling protocol.
 
 Like the previous exercises, running the `make` command creates a new
 docker container and runs the program `main.py`, which compiles the P4

--- a/p4app-exercises/p4runtime.p4app/advanced_tunnel.p4
+++ b/p4app-exercises/p4runtime.p4app/advanced_tunnel.p4
@@ -166,14 +166,15 @@ control MyIngress(inout headers hdr,
     }
 
     apply {
-        if (hdr.ipv4.isValid() && !hdr.myTunnel.isValid()) {
-            // Process only non-tunneled IPv4 packets.
-            ipv4_lpm.apply();
-        }
-
-        if (hdr.myTunnel.isValid()) {
-            // Process all tunneled packets.
+        if (!hdr.ipv4.isValid() && !hdr.myTunnel.isValid()) {
+            // drop non-tunneled, non-IPv4 packets
+            drop();
+        } else if (hdr.myTunnel.isValid()) {
+            // process tunneled packets
             myTunnel_exact.apply();
+        } else {
+            // process non-tunneled IPv4 packets
+            ipv4_lpm.apply();
         }
     }
 }

--- a/p4app-exercises/p4runtime.p4app/advanced_tunnel.p4
+++ b/p4app-exercises/p4runtime.p4app/advanced_tunnel.p4
@@ -169,12 +169,16 @@ control MyIngress(inout headers hdr,
         if (!hdr.ipv4.isValid() && !hdr.myTunnel.isValid()) {
             // drop non-tunneled, non-IPv4 packets
             drop();
-        } else if (hdr.myTunnel.isValid()) {
-            // process tunneled packets
-            myTunnel_exact.apply();
         } else {
-            // process non-tunneled IPv4 packets
-            ipv4_lpm.apply();
+            if (!hdr.myTunnel.isValid()) {
+                // process non-tunneled IPv4 packets
+                ipv4_lpm.apply();
+            }
+            if (hdr.myTunnel.isValid()) {
+                // process tunneled packets, including the ones encapsulated by
+                // the ipv4_lpm table
+                myTunnel_exact.apply();
+            }
         }
     }
 }


### PR DESCRIPTION
Not doing anyhting means for v1model & bmv2 forwarding on port 0. In the
case of p4app there is no port 0, but the bmv2 logs would still show the
pacjet as being forwarded oout of port 0, even if the packet is not
going anywhere...