### PR TITLE
Several proposed changes to v1model standard_metadata for cheat sheet

### DIFF
--- a/utils/cheat_sheet_src/src/v1model_std_metadata.txt
+++ b/utils/cheat_sheet_src/src/v1model_std_metadata.txt
@@ -1,22 +1,27 @@
 struct standard_metadata_t {
+    // For more details see docs/simple_switch.md
+    // in https://github.com/p4lang/behavioral-model
+
+    // should only read, ingress or egress
     bit<9>  ingress_port;
-    bit<9>  egress_spec;
-    bit<9>  egress_port;
-    bit<32> clone_spec;
     bit<32> instance_type;
-    bit<1>  drop;
-    bit<16> recirculate_port;
     bit<32> packet_length;
+    bit<48> ingress_global_timestamp;
+    bit<1>  checksum_error;
+    error   parser_error;
+
+    // read/write, ingress
+    bit<9>  egress_spec;
+    bit<16> mcast_grp;
+
+    // should only read, egress only
+    bit<9>  egress_port;
+    bit<16> egress_rid;
+    bit<48> egress_global_timestamp;
     bit<32> enq_timestamp;
     bit<19> enq_qdepth;
     bit<32> deq_timedelta;
     bit<19> deq_qdepth;
-    bit<48> ingress_global_timestamp;
-    bit<48> egress_global_timestamp;
-    bit<32> lf_field_list;
-    bit<16> mcast_grp;
-    bit<32> resubmit_flag;
-    bit<16> egress_rid;
-    bit<1>  checksum_error;
-    bit<32> recirculate_flag;
+
+    // Some useless fields have been left out.
 }

--- a/utils/cheat_sheet_src/src/v1model_std_metadata.txt
+++ b/utils/cheat_sheet_src/src/v1model_std_metadata.txt
@@ -2,7 +2,7 @@ struct standard_metadata_t {
     // For more details see docs/simple_switch.md
     // in https://github.com/p4lang/behavioral-model
 
-    // should only read, ingress or egress
+    // Should only read, ingress or egress
     bit<9>  ingress_port;
     bit<32> instance_type;
     bit<32> packet_length;
@@ -10,11 +10,12 @@ struct standard_metadata_t {
     bit<1>  checksum_error;
     error   parser_error;
 
-    // read/write, ingress
+    // In ingress, read or write.
+    // In egress, should only read.
     bit<9>  egress_spec;
     bit<16> mcast_grp;
 
-    // should only read, egress only
+    // Should only read, only in egress
     bit<9>  egress_port;
     bit<16> egress_rid;
     bit<48> egress_global_timestamp;
@@ -22,6 +23,4 @@ struct standard_metadata_t {
     bit<19> enq_qdepth;
     bit<32> deq_timedelta;
     bit<19> deq_qdepth;
-
-    // Some useless fields have been left out.
 }


### PR DESCRIPTION
Remove several fields that are deprecated in the v1model.p4 include file,
or will be soon:

+ drop
+ recirculate_port
+ clone_spec
+ lf_field_list
+ resubmit_flag
+ recirculate_flag

Add mention of more detailed documentation in behavioral-model
repository, for those that want to know more about how each field
behaves.

Group the fields by those that are only intended to be read in a P4
program, versues read/write, and which are only intended to be useful
in ingress, egress, or both.