### PR TITLE
No longer try installing Python grip package

### DIFF
--- a/vm/user-bootstrap.sh
+++ b/vm/user-bootstrap.sh
@@ -117,8 +117,6 @@ sudo pip install crcmod
 git clone https://github.com/p4lang/tutorials
 sudo mv tutorials /home/p4
 sudo chown -R p4:p4 /home/p4/tutorials
-# Install grip for offline markdown rendering
-sudo pip install grip
 
 # --- Emacs --- #
 sudo cp p4_16-mode.el /usr/share/emacs/site-lisp/


### PR DESCRIPTION
As of 2020-May-09, and probably some months earlier, attempting to
install the Python 'grip' package fails on Ubuntu 16.04 systems.  This
package is not essential for using the P4 open source development
tools.