### PR TITLE
changed default graphics controller for macos

### DIFF
--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(2) do |config|
                 "--port", "0", "--device", "0", 
                 "--type", "dvddrive", 
                 "--medium", "emptydrive"]    
-    vb.customize ["modifyvm", :id, "--vram", "32"]
+    vb.customize ["modifyvm", :id, "--vram", "32","--graphicscontroller", "vmsvga"]
 
   end
   config.vm.synced_folder '.', '/vagrant', disabled: true  


### PR DESCRIPTION
On MacOS the virtual machine would not update its display unless it was deselected and then selected again. I changed the default graphics controller for the virtual machine and that solved the issue. 