### PR TITLE
move next_thrift_port to class P4Switch

### DIFF
--- a/utils/p4_mininet.py
+++ b/utils/p4_mininet.py
@@ -57,6 +57,7 @@ class P4Host(Host):
 class P4Switch(Switch):
     """P4 virtual switch"""
     device_id = 0
+    next_thrift_port = 9090
 
     def __init__(self, name, sw_path = None, json_path = None,
                  thrift_port = None,
@@ -81,7 +82,13 @@ class P4Switch(Switch):
         self.verbose = verbose
         logfile = "/tmp/p4s.{}.log".format(self.name)
         self.output = open(logfile, 'w')
-        self.thrift_port = thrift_port
+
+        if thrift_port is not None:
+            self.thrift_port = thrift_port
+        else:
+            self.thrift_port = P4Switch.next_thrift_port
+            P4Switch.next_thrift_port += 1
+
         if check_listening_on_port(self.thrift_port):
             error('%s cannot bind port %d because it is bound by another process\n' % (self.name, self.grpc_port))
             exit(1)

--- a/utils/p4runtime_switch.py
+++ b/utils/p4runtime_switch.py
@@ -27,7 +27,6 @@ from netstat import check_listening_on_port
 class P4RuntimeSwitch(P4Switch):
     "BMv2 switch with gRPC support"
     next_grpc_port = 50051
-    next_thrift_port = 9090
 
     def __init__(self, name, sw_path = None, json_path = None,
                  grpc_port = None,
@@ -63,8 +62,8 @@ class P4RuntimeSwitch(P4Switch):
         if thrift_port is not None:
             self.thrift_port = thrift_port
         else:
-            self.thrift_port = P4RuntimeSwitch.next_thrift_port
-            P4RuntimeSwitch.next_thrift_port += 1
+            self.thrift_port = P4Switch.next_thrift_port
+            P4Switch.next_thrift_port += 1
 
         if check_listening_on_port(self.grpc_port):
             error('%s cannot bind port %d because it is bound by another process\n' % (self.name, self.grpc_port))

--- a/utils/run_exercise.py
+++ b/utils/run_exercise.py
@@ -46,16 +46,14 @@ def configureP4Switch(**switch_args):
 
             def describe(self):
                 print "%s -> gRPC port: %d" % (self.name, self.grpc_port)
+                print "%s -> Thrift port: %d" % (self.name, self.thrift_port)
 
         return ConfiguredP4RuntimeSwitch
     else:
         class ConfiguredP4Switch(P4Switch):
-            next_thrift_port = 9090
             def __init__(self, *opts, **kwargs):
                 global next_thrift_port
                 kwargs.update(switch_args)
-                kwargs['thrift_port'] = ConfiguredP4Switch.next_thrift_port
-                ConfiguredP4Switch.next_thrift_port += 1
                 P4Switch.__init__(self, *opts, **kwargs)
 
             def describe(self):


### PR DESCRIPTION
I want to start a network that has several switches with `simple_switch`, and load p4 program by setting 'program' option in **topology.json**:

```json
···
    "switches": {
        "s1": { "program": "build/basic.json",
                "cli_input" : "linear-topo/s1-cli.txt" },
        "s2": { "program": "build/basic.json",
                "cli_input" : "linear-topo/s2-cli.txt" }
    },
    "links": [
        ["h1", "s1-p1"], ["h2", "s2-p1"], ["s1-p2", "s2-p2"]    ]
···
```

However, both thrift port of s1 and s2 will be set to _9090_, as the function `configureP4Switch` in `run_exercise.py`  does not return the same object of class `ConfiguredP4Switch` .

I move the `next_thrift_port` property to class `P4Switch`, so that the thrift port number will be incremented just like grpc port.