### PR TITLE
Without these additions, some files did not have execute permissions

### DIFF
--- a/vm-ubuntu-20.04/Vagrantfile
+++ b/vm-ubuntu-20.04/Vagrantfile
@@ -25,10 +25,12 @@ Vagrant.configure(2) do |config|
   config.vm.provision "file", source: "p4_16-mode.el", destination: "/home/vagrant/p4_16-mode.el"
   config.vm.provision "file", source: "p4.vim",        destination: "/home/vagrant/p4.vim"
   config.vm.provision "file", source: "py3localpath.py", destination: "/home/vagrant/py3localpath.py"
+  config.vm.provision "shell", inline: "chmod 755 /home/vagrant/py3localpath.py"
   config.vm.provision "file", source: "patches/disable-Wno-error-and-other-small-changes.diff", destination: "/home/vagrant/patches/disable-Wno-error-and-other-small-changes.diff"
   config.vm.provision "file", source: "patches/behavioral-model-use-correct-libssl-pkg.patch", destination: "/home/vagrant/patches/behavioral-model-use-correct-libssl-pkg.patch"
   config.vm.provision "file", source: "patches/mininet-dont-install-python2.patch", destination: "/home/vagrant/patches/mininet-dont-install-python2.patch"
   config.vm.provision "file", source: "clean.sh", destination: "/home/vagrant/clean.sh"
+  config.vm.provision "shell", inline: "chmod 755 /home/vagrant/clean.sh"
   config.vm.provision "shell", path: "root-bootstrap.sh"
   config.vm.provision "shell", privileged: false, path: "user-bootstrap.sh"
 end


### PR DESCRIPTION
when running 'vagrant up' on a Windows 10 host OS.