### PR TITLE
No longer attempt to install the Sublime Text editor during `vagrant up`

### DIFF
--- a/vm-ubuntu-20.04/README.md
+++ b/vm-ubuntu-20.04/README.md
@@ -36,8 +36,8 @@ new VM very often (a couple of times per year?).
   + Close "Desktop preferences" window
 + Several of the icons on the desktop have an exclamation mark on
   them.  If you try double-clicking those icons, it pops up a window
-  saying "This file 'Sublime Text' seems to be a desktop entry.  What
-  do you want to do with it?" with buttons for "Open", "Execute", and
+  saying "This file 'Wireshark' seems to be a desktop entry.  What do
+  you want to do with it?" with buttons for "Open", "Execute", and
   "Cancel".  Clicking "Open" causes the file to be opened using the
   Atom editor.  Clicking "Execute" executes the associated command.
   If you do a mouse middle click on one of these desktop icons, a
@@ -46,7 +46,6 @@ new VM very often (a couple of times per year?).
   and future double-clicks of the icon execute the program without
   first popping up a window to choose between Open/Execute/Cancel.  I
   did that for each of these desktop icons:
-  + Sublime Text
   + Terminal
   + Wireshark
 + Log off

--- a/vm-ubuntu-20.04/root-bootstrap.sh
+++ b/vm-ubuntu-20.04/root-bootstrap.sh
@@ -3,19 +3,6 @@
 # Print commands and exit on errors
 set -xe
 
-# Sublime 3 install steps came from this page on 2020-May-11:
-# https://www.sublimetext.com/docs/3/linux_repositories.html#apt
-# The commands were modified only to remove 'sudo' from several
-# commands.  sudo is unnecessary here since this entire script is
-# executed as the user root.
-
-wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | apt-key add -
-apt-get install apt-transport-https
-echo "deb https://download.sublimetext.com/ apt/stable/" | tee /etc/apt/sources.list.d/sublime-text.list
-# These commands are done later below
-#apt-get update
-#apt-get install sublime-text
-
 # Atom install steps came from this page on 2020-May-11:
 # https://flight-manual.atom.io/getting-started/sections/installing-atom/#platform-linux
 
@@ -77,7 +64,6 @@ apt-get install -y --no-install-recommends --fix-missing\
   python3-dev \
   python3-pip \
   python3-setuptools \
-  sublime-text \
   tcpdump \
   unzip \
   valgrind \

--- a/vm-ubuntu-20.04/user-bootstrap.sh
+++ b/vm-ubuntu-20.04/user-bootstrap.sh
@@ -288,17 +288,6 @@ Exec=/usr/bin/wireshark
 Comment[en_US]=
 EOF
 
-cat > ${DESKTOP}/Sublime\ Text.desktop << EOF
-[Desktop Entry]
-Encoding=UTF-8
-Type=Application
-Name=Sublime Text
-Name[en_US]=Sublime Text
-Icon=sublime-text
-Exec=/opt/sublime_text/sublime_text
-Comment[en_US]=
-EOF
-
 sudo mkdir -p /home/p4/Desktop
 sudo mv /home/${USER}/Desktop/* /home/p4/Desktop
 sudo chown -R p4:p4 /home/p4/Desktop/


### PR DESCRIPTION
Starting around 2021-Sep, the official published instructions for
installing Sublime Text on Ubuntu Linux no longer seem to work.  If
this continues for much longer, it would be a good idea if the
`vagrant up` scripts no longer attempted to install it.