### PR TITLE
Fix calc example

### DIFF
--- a/exercises/calc/calc.py
+++ b/exercises/calc/calc.py
@@ -68,7 +68,7 @@ def main():
     iface = 'eth0'
 
     while True:
-        s = str(eval(input('> ')))
+        s = input('> ')
         if s == "quit":
             break
         print(s)


### PR DESCRIPTION
Function eval() calculate already the result before sending inputs to the switch (the calculation should be done by the switch) So, it should be removed.