### PR TITLE
Important Installation Fix

### DIFF
--- a/vm-ubuntu-20.04/root-bootstrap.sh
+++ b/vm-ubuntu-20.04/root-bootstrap.sh
@@ -9,9 +9,9 @@ set -xe
 # commands.  sudo is unnecessary here since this entire script is
 # executed as the user root.
 
-wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | apt-key add -
+wget -qO - http://download.sublimetext.com/sublimehq-pub.gpg | apt-key add -
 apt-get install apt-transport-https
-echo "deb https://download.sublimetext.com/ apt/stable/" | tee /etc/apt/sources.list.d/sublime-text.list
+echo "deb http://download.sublimetext.com/ apt/stable/" | tee /etc/apt/sources.list.d/sublime-text.list
 # These commands are done later below
 #apt-get update
 #apt-get install sublime-text


### PR DESCRIPTION
Handshake request fails at https://download.sublimetext.com/ apt/stable/" during the installation, making the whole repository not install at all for new environments. This fix is required as the sublimetext servers had troubles for weeks and the installation wasn't possible for a month due to this issue. 