### PR TITLE
vm: Fix py3localpath shebang

### DIFF
--- a/vm-ubuntu-20.04/py3localpath.py
+++ b/vm-ubuntu-20.04/py3localpath.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 import re
 import sys


### PR DESCRIPTION
This pull request removes a space between `#!` and the Python interpreter in the shebang of `py3localpath.py`
