### PR TITLE
utils: Fix encoding for range match type

### DIFF
--- a/utils/p4runtime_lib/helper.py
+++ b/utils/p4runtime_lib/helper.py
@@ -110,8 +110,8 @@ class P4InfoHelper(object):
             lpm.mask = encode(value[1], bitwidth)
         elif match_type == p4info_pb2.MatchField.RANGE:
             lpm = p4runtime_match.range
-            lpm.low = encode(value[0], bitwidth)
-            lpm.high = encode(value[1], bitwidth)
+            lpm.low = (value[0]).to_bytes(bitwidth, byteorder='big')
+            lpm.high = (value[1]).to_bytes(bitwidth, byteorder='big')
         else:
             raise Exception("Unsupported match type with type %r" % match_type)
         return p4runtime_match


### PR DESCRIPTION
This pull request fixes the encoding functionality for the range match type.

For example, if we modify the `check_ports` table in the [firewall](https://github.com/p4lang/tutorials/blob/ccc56938075eefd5ea36c083cf53de9fb55c933a/exercises/firewall/solution/firewall.p4) exercise to use a _range_ match type as follows:
```P4
table check_ports {
    key = {
        standard_metadata.ingress_port: range;
        standard_metadata.egress_spec: exact;
    }
    actions = {
        set_direction;
        NoAction;
    }
    size = 1024;
    default_action = NoAction();
}
```
This fix would allow to insert [table entries](https://github.com/p4lang/tutorials/blob/ccc56938075eefd5ea36c083cf53de9fb55c933a/exercises/firewall/pod-topo/s1-runtime.json) using the following JSON format:
```json
  "table_entries": [
    {
      "table": "MyIngress.check_ports",
      "match": {
        "standard_metadata.ingress_port": [1, 2],
        "standard_metadata.egress_spec": 3
      },
      "priority": 1,
      "action_name": "MyIngress.set_direction",
      "action_params": {
        "dir": 0
      }
    },
```
Note that the `priority` field for this table entry is required.