### PR TITLE
utils: show error message when priority is missing

### DIFF
--- a/utils/p4runtime_lib/helper.py
+++ b/utils/p4runtime_lib/helper.py
@@ -101,17 +101,17 @@ class P4InfoHelper(object):
             exact = p4runtime_match.exact
             exact.value = encode(value, bitwidth)
         elif match_type == p4info_pb2.MatchField.LPM:
-            lpm = p4runtime_match.lpm
-            lpm.value = encode(value[0], bitwidth)
-            lpm.prefix_len = value[1]
+            lpm_entry = p4runtime_match.lpm
+            lpm_entry.value = encode(value[0], bitwidth)
+            lpm_entry.prefix_len = value[1]
         elif match_type == p4info_pb2.MatchField.TERNARY:
-            lpm = p4runtime_match.ternary
-            lpm.value = encode(value[0], bitwidth)
-            lpm.mask = encode(value[1], bitwidth)
+            ternary_entry = p4runtime_match.ternary
+            ternary_entry.value = encode(value[0], bitwidth)
+            ternary_entry.mask = encode(value[1], bitwidth)
         elif match_type == p4info_pb2.MatchField.RANGE:
-            lpm = p4runtime_match.range
-            lpm.low = encode(value[0], bitwidth)
-            lpm.high = encode(value[1], bitwidth)
+            range_entry = p4runtime_match.range
+            range_entry.low = encode(value[0], bitwidth)
+            range_entry.high = encode(value[1], bitwidth)
         else:
             raise Exception("Unsupported match type with type %r" % match_type)
         return p4runtime_match

--- a/utils/run_exercise.py
+++ b/utils/run_exercise.py
@@ -273,7 +273,9 @@ class ExerciseRunner:
                 device_id=device_id,
                 sw_conf_file=sw_conf_file,
                 workdir=os.getcwd(),
-                proto_dump_fpath=outfile)
+                proto_dump_fpath=outfile,
+                runtime_json=runtime_json
+            )
 
     def program_switch_cli(self, sw_name, sw_dict):
         """ This method will start up the CLI and use the contents of the


### PR DESCRIPTION
This pull request adds a validation for P4Runtime table entries that shows an error message when the `priority` field is required but not specified. For example:

> AssertionError: non-zero 'priority' field is required for all entries for table MyIngress.check_ports in pod-topo/s1-runtime.json
