### PR TITLE
clean up trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ you get started with P4 programming, organized into several modules:
 * [Firewall](./exercises/firewall)
 * [Link Monitoring](./exercises/link_monitor)
 
-## Presentation 
+## Presentation
 
 The slides are available [online](http://bit.ly/p4d2-2018-spring) and
 in the P4_tutorial.pdf in the tutorial directory.
@@ -46,7 +46,7 @@ The documentation for P4_16 and P4Runtime is available [here](https://p4.org/spe
 All excercises in this repository use the v1model architecture, the documentation for which is available at:
 1. The BMv2 Simple Switch target document accessible [here](https://github.com/p4lang/behavioral-model/blob/master/docs/simple_switch.md) talks mainly about the v1model architecture.
 2. The include file `v1model.p4` has extensive comments and can be accessed [here](https://github.com/p4lang/p4c/blob/master/p4include/v1model.p4).
-        
+
 ## Obtaining required software
 
 If you are starting this tutorial at one of the proctored tutorial events,

--- a/exercises/basic/basic.p4
+++ b/exercises/basic/basic.p4
@@ -62,7 +62,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -77,11 +77,11 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         /* TODO: fill out code in action body */
     }
-    
+
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: lpm;
@@ -94,7 +94,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = NoAction();
     }
-    
+
     apply {
         /* TODO: fix ingress control logic
          *  - ipv4_lpm should be applied only when IPv4 header is valid
@@ -119,10 +119,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/basic/solution/basic.p4
+++ b/exercises/basic/solution/basic.p4
@@ -74,7 +74,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -89,14 +89,14 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: lpm;
@@ -109,7 +109,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = drop();
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
@@ -133,10 +133,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+        hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/basic/triangle-topo/topology.json
+++ b/exercises/basic/triangle-topo/topology.json
@@ -16,7 +16,7 @@
         "s3": { "runtime_json" : "triangle-topo/s3-runtime.json" }
     },
     "links": [
-        ["h1", "s1-p1"], ["s1-p2", "s2-p2"], ["s1-p3", "s3-p2"], 
+        ["h1", "s1-p1"], ["s1-p2", "s2-p2"], ["s1-p3", "s3-p2"],
         ["s3-p3", "s2-p3"], ["h2", "s2-p1"], ["h3", "s3-p1"]
     ]
 }

--- a/exercises/basic_tunnel/basic_tunnel.p4
+++ b/exercises/basic_tunnel/basic_tunnel.p4
@@ -86,7 +86,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -101,14 +101,14 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: lpm;
@@ -153,10 +153,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/basic_tunnel/solution/basic_tunnel.p4
+++ b/exercises/basic_tunnel/solution/basic_tunnel.p4
@@ -90,7 +90,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -105,14 +105,14 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: lpm;
@@ -125,7 +125,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = drop();
     }
-    
+
     action myTunnel_forward(egressSpec_t port) {
         standard_metadata.egress_spec = port;
     }
@@ -171,10 +171,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/calc/README.md
+++ b/exercises/calc/README.md
@@ -23,7 +23,7 @@ switch in Mininet to test its behavior.
    ```
    This will:
    * compile `calc.p4`, and
-  
+
    * start a Mininet instance with one switches (`s1`) connected to
      two hosts (`h1`, `h2`).
    * The hosts are assigned IPs of `10.0.1.1` and `10.0.1.2`.
@@ -33,8 +33,8 @@ you to test your calculator. You can run the driver program directly
 from the Mininet command prompt:
 
 ```
-mininet> h1 python calc.py 
-> 
+mininet> h1 python calc.py
+>
 ```
 
 3. The driver program will provide a new prompt, at which you can type
@@ -70,7 +70,7 @@ We will use the following header format:
       +----------------+----------------+----------------+---------------+
       |                              Result                              |
       +----------------+----------------+----------------+---------------+
- 
+
 
 -  P is an ASCII Letter 'P' (0x50)
 -  4 is an ASCII Letter '4' (0x34)
@@ -81,7 +81,7 @@ We will use the following header format:
  -   '&' (0x26) Result = OperandA & OperandB
  -   '|' (0x7c) Result = OperandA | OperandB
  -   '^' (0x5e) Result = OperandA ^ OperandB
- 
+
 
 We will assume that the calculator header is carried over Ethernet,
 and we will use the Ethernet type 0x1234 to indicate the presence of

--- a/exercises/calc/calc.p4
+++ b/exercises/calc/calc.p4
@@ -29,12 +29,12 @@
  *   '|' (0x7c) Result = OperandA | OperandB
  *   '^' (0x5e) Result = OperandA ^ OperandB
  *
- * The device receives a packet, performs the requested operation, fills in the 
- * result and sends the packet back out of the same port it came in on, while 
+ * The device receives a packet, performs the requested operation, fills in the
+ * result and sends the packet back out of the same port it came in on, while
  * swapping the source and destination addresses.
  *
  * If an unknown operation is specified or the header is not valid, the packet
- * is dropped 
+ * is dropped
  */
 
 #include <core.p4>
@@ -45,7 +45,7 @@
  */
 
 /*
- * Standard Ethernet header 
+ * Standard Ethernet header
  */
 header ethernet_t {
     bit<48> dstAddr;
@@ -54,7 +54,7 @@ header ethernet_t {
 }
 
 /*
- * This is a custom protocol header for the calculator. We'll use 
+ * This is a custom protocol header for the calculator. We'll use
  * etherType 0x1234 for it (see parser)
  */
 const bit<16> P4CALC_ETYPE = 0x1234;
@@ -86,12 +86,12 @@ struct headers {
 }
 
 /*
- * All metadata, globally used in the program, also  needs to be assembled 
- * into a single struct. As in the case of the headers, we only need to 
+ * All metadata, globally used in the program, also  needs to be assembled
+ * into a single struct. As in the case of the headers, we only need to
  * declare the type, but there is no need to instantiate it,
  * because it is done "by the architecture", i.e. outside of P4 functions
  */
- 
+
 struct metadata {
     /* In our case it is empty */
 }
@@ -102,7 +102,7 @@ struct metadata {
 parser MyParser(packet_in packet,
                 out headers hdr,
                 inout metadata meta,
-                inout standard_metadata_t standard_metadata) {    
+                inout standard_metadata_t standard_metadata) {
     state start {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {
@@ -110,10 +110,10 @@ parser MyParser(packet_in packet,
             default      : accept;
         }
     }
-    
+
     state check_p4calc {
         /* TODO: just uncomment the following parse block */
-        /* 
+        /*
         transition select(packet.lookahead<p4calc_t>().p,
         packet.lookahead<p4calc_t>().four,
         packet.lookahead<p4calc_t>().ver) {
@@ -122,7 +122,7 @@ parser MyParser(packet_in packet,
         }
         */
     }
-    
+
     state parse_p4calc {
         packet.extract(hdr.p4calc);
         transition accept;
@@ -151,21 +151,21 @@ control MyIngress(inout headers hdr,
          * - Send the packet back to the port it came from
              by saving standard_metadata.ingress_port into
              standard_metadata.egress_spec
-         */ 
+         */
     }
-    
+
     action operation_add() {
         /* TODO call send_back with operand_a + operand_b */
     }
-    
+
     action operation_sub() {
         /* TODO call send_back with operand_a - operand_b */
     }
-    
+
     action operation_and() {
         /* TODO call send_back with operand_a & operand_b */
     }
-    
+
     action operation_or() {
         /* TODO call send_back with operand_a | operand_b */
     }
@@ -177,7 +177,7 @@ control MyIngress(inout headers hdr,
     action operation_drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     table calculate {
         key = {
             hdr.p4calc.op        : exact;
@@ -199,7 +199,7 @@ control MyIngress(inout headers hdr,
             P4CALC_CARET: operation_xor();
         }
     }
-            
+
     apply {
         if (hdr.p4calc.isValid()) {
             calculate.apply();

--- a/exercises/calc/solution/calc.p4
+++ b/exercises/calc/solution/calc.p4
@@ -29,12 +29,12 @@
  *   '|' (0x7c) Result = OperandA | OperandB
  *   '^' (0x5e) Result = OperandA ^ OperandB
  *
- * The device receives a packet, performs the requested operation, fills in the 
- * result and sends the packet back out of the same port it came in on, while 
+ * The device receives a packet, performs the requested operation, fills in the
+ * result and sends the packet back out of the same port it came in on, while
  * swapping the source and destination addresses.
  *
  * If an unknown operation is specified or the header is not valid, the packet
- * is dropped 
+ * is dropped
  */
 
 #include <core.p4>
@@ -45,7 +45,7 @@
  */
 
 /*
- * Standard ethernet header 
+ * Standard ethernet header
  */
 header ethernet_t {
     bit<48> dstAddr;
@@ -54,7 +54,7 @@ header ethernet_t {
 }
 
 /*
- * This is a custom protocol header for the calculator. We'll use 
+ * This is a custom protocol header for the calculator. We'll use
  * ethertype 0x1234 for is (see parser)
  */
 const bit<16> P4CALC_ETYPE = 0x1234;
@@ -88,12 +88,12 @@ struct headers {
 }
 
 /*
- * All metadata, globally used in the program, also  needs to be assembed 
- * into a single struct. As in the case of the headers, we only need to 
+ * All metadata, globally used in the program, also  needs to be assembed
+ * into a single struct. As in the case of the headers, we only need to
  * declare the type, but there is no need to instantiate it,
  * because it is done "by the architecture", i.e. outside of P4 functions
  */
- 
+
 struct metadata {
     /* In our case it is empty */
 }
@@ -113,7 +113,7 @@ parser MyParser(packet_in packet,
             default      : accept;
         }
     }
-    
+
     state check_p4calc {
         transition select(packet.lookahead<p4calc_t>().p,
         packet.lookahead<p4calc_t>().four,
@@ -122,7 +122,7 @@ parser MyParser(packet_in packet,
             default                          : accept;
         }
     }
-    
+
     state parse_p4calc {
         packet.extract(hdr.p4calc);
         transition accept;
@@ -143,34 +143,34 @@ control MyVerifyChecksum(inout headers hdr,
 control MyIngress(inout headers hdr,
                   inout metadata meta,
                   inout standard_metadata_t standard_metadata) {
-    
+
     action send_back(bit<32> result) {
         bit<48> tmp;
 
         /* Put the result back in */
         hdr.p4calc.res = result;
-        
+
         /* Swap the MAC addresses */
         tmp = hdr.ethernet.dstAddr;
         hdr.ethernet.dstAddr = hdr.ethernet.srcAddr;
         hdr.ethernet.srcAddr = tmp;
-        
+
         /* Send the packet back to the port it came from */
         standard_metadata.egress_spec = standard_metadata.ingress_port;
     }
-    
+
     action operation_add() {
         send_back(hdr.p4calc.operand_a + hdr.p4calc.operand_b);
     }
-    
+
     action operation_sub() {
         send_back(hdr.p4calc.operand_a - hdr.p4calc.operand_b);
     }
-    
+
     action operation_and() {
         send_back(hdr.p4calc.operand_a & hdr.p4calc.operand_b);
     }
-    
+
     action operation_or() {
         send_back(hdr.p4calc.operand_a | hdr.p4calc.operand_b);
     }
@@ -182,7 +182,7 @@ control MyIngress(inout headers hdr,
     action operation_drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     table calculate {
         key = {
             hdr.p4calc.op        : exact;
@@ -205,7 +205,7 @@ control MyIngress(inout headers hdr,
         }
     }
 
-            
+
     apply {
         if (hdr.p4calc.isValid()) {
             calculate.apply();

--- a/exercises/ecn/ecn.p4
+++ b/exercises/ecn/ecn.p4
@@ -78,7 +78,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -93,7 +93,7 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
@@ -112,7 +112,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = drop;
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
@@ -131,7 +131,7 @@ control MyEgress(inout headers hdr,
         /*
          * TODO:
          * - if ecn is 1 or 2
-         *   - compare standard_metadata.enq_qdepth with threshold 
+         *   - compare standard_metadata.enq_qdepth with threshold
          *     and set hdr.ipv4.ecn to 3 if larger
          */
     }
@@ -144,8 +144,8 @@ control MyEgress(inout headers hdr,
 control MyComputeChecksum(inout headers hdr, inout metadata meta) {
     apply {
         /* TODO: replace tos with diffserve and ecn */
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
               hdr.ipv4.ihl,
               hdr.ipv4.tos,

--- a/exercises/ecn/s1-runtime.json
+++ b/exercises/ecn/s1-runtime.json
@@ -25,7 +25,7 @@
         "port": 1
       }
     },
- 
+
     {
       "table": "MyIngress.ipv4_lpm",
       "match": {

--- a/exercises/ecn/solution/ecn.p4
+++ b/exercises/ecn/solution/ecn.p4
@@ -76,7 +76,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -91,7 +91,7 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
@@ -111,7 +111,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = NoAction();
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
@@ -144,12 +144,12 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
-	      hdr.ipv4.diffserv,
-	      hdr.ipv4.ecn,	
+              hdr.ipv4.ihl,
+              hdr.ipv4.diffserv,
+              hdr.ipv4.ecn,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,
               hdr.ipv4.flags,

--- a/exercises/firewall/README.md
+++ b/exercises/firewall/README.md
@@ -14,7 +14,7 @@ would be in a single pod of a fat tree topology.
 ![topology](./firewall-topo.png)
 
 Switch s1 will be configured with a P4 program that implements a
-simple stateful firewall (`firewall.p4`), the rest of the switches will run the 
+simple stateful firewall (`firewall.p4`), the rest of the switches will run the
 basic IPv4 router program (`basic.p4`) from the previous exercise.
 
 The firewall on s1 should have the following functionality:
@@ -62,21 +62,21 @@ up a switch in Mininet to test its behavior.
    [pod-topo/topology.json](./pod-topo/topology.json)
 
 2. You should now see a Mininet command prompt. Try to run some iperf
-   TCP flows between the hosts. TCP flows within the internal 
+   TCP flows between the hosts. TCP flows within the internal
    network should work:
    ```bash
    mininet> iperf h1 h2
    ```
 
-   TCP flows from hosts in the internal network to the outside hosts 
+   TCP flows from hosts in the internal network to the outside hosts
    should also work:
    ```bash
    mininet> iperf h1 h3
-   ```   
+   ```
 
-   TCP flows from the outside hosts to hosts inside the 
-   internal network should NOT work. However, since the firewall is not 
-   implemented yet, the following should work: 
+   TCP flows from the outside hosts to hosts inside the
+   internal network should NOT work. However, since the firewall is not
+   implemented yet, the following should work:
    ```bash
    mininet> iperf h3 h1
    ```
@@ -118,11 +118,11 @@ logic replaced by `TODO` comments. Your implementation should follow
 the structure given in this file --- replace each `TODO` with logic
 implementing the missing piece.
 
-**High-level Approach:** We will use a bloom filter with two hash functions 
-to check if a packet coming into the internal network is a part of 
-an already established TCP connection. We will use two different register 
-arrays for the bloom filter, each to be updated by a hash function. 
-Using different register arrays makes our design amenable to high-speed 
+**High-level Approach:** We will use a bloom filter with two hash functions
+to check if a packet coming into the internal network is a part of
+an already established TCP connection. We will use two different register
+arrays for the bloom filter, each to be updated by a hash function.
+Using different register arrays makes our design amenable to high-speed
 P4 targets that typically allow only one access to a register array per packet.
 
 A complete `firewall.p4` will contain the following components:
@@ -130,32 +130,32 @@ A complete `firewall.p4` will contain the following components:
 1. Header type definitions for Ethernet (`ethernet_t`), IPv4 (`ipv4_t`) and TCP (`tcp_t`).
 2. Parsers for Ethernet, IPv4 and TCP that populate `ethernet_t`, `ipv4_t` and `tcp_t` fields.
 3. An action to drop a packet, using `mark_to_drop()`.
-4. An action (called `compute_hashes`) to compute the bloom filter's two hashes using hash 
-algorithms `crc16` and `crc32`. The hashes will be computed on the packet 5-tuple consisting 
-of IPv4 source and  destination addresses, source and destination port numbers and 
+4. An action (called `compute_hashes`) to compute the bloom filter's two hashes using hash
+algorithms `crc16` and `crc32`. The hashes will be computed on the packet 5-tuple consisting
+of IPv4 source and  destination addresses, source and destination port numbers and
 the IPv4 protocol type.
-5. An action (`ipv4_forward`) and a table (`ipv4_lpm`) that will perform basic 
+5. An action (`ipv4_forward`) and a table (`ipv4_lpm`) that will perform basic
 IPv4 forwarding (adopted from `basic.p4`).
-6. An action (called `set_direction`) that will simply set a one-bit direction variable 
+6. An action (called `set_direction`) that will simply set a one-bit direction variable
 as per the action's parameter.
-7. A table (called `check_ports`) that will read the ingress and egress port of a packet 
-(after IPv4 forwarding) and invoke `set_direction`. The direction will be set to `1`, 
+7. A table (called `check_ports`) that will read the ingress and egress port of a packet
+(after IPv4 forwarding) and invoke `set_direction`. The direction will be set to `1`,
 if the packet is incoming into the internal network. Otherwise, the direction will be set to `0`.
 To achieve this, the file `pod-topo/s1-runtime.json` contains the appropriate control plane
 entries for the `check_ports` table.
 8. A control that will:
     1. First apply the table `ipv4_lpm` if the packet has a valid IPv4 header.
     2. Then if the TCP header is valid, apply the `check_ports` table to determine the direction.
-    3. Apply the `compute_hashes` action to compute the two hash values which are the bit positions 
-    in the two register arrays of the bloom filter (`reg_pos_one` and `reg_pos_two`). 
-    When the direction is `1` i.e. the packet is incoming into the internal network, 
-    `compute_hashes` will be invoked by swapping the source and destination IPv4 addresses 
-    and the source and destination ports. This is to check against bloom filter's set bits 
+    3. Apply the `compute_hashes` action to compute the two hash values which are the bit positions
+    in the two register arrays of the bloom filter (`reg_pos_one` and `reg_pos_two`).
+    When the direction is `1` i.e. the packet is incoming into the internal network,
+    `compute_hashes` will be invoked by swapping the source and destination IPv4 addresses
+    and the source and destination ports. This is to check against bloom filter's set bits
     when the TCP connection was initially made from the internal network.
-    4. **TODO:** If the TCP packet is going out of the internal network and is a SYN packet, 
-    set both the bloom filter arrays at the computed bit positions (`reg_pos_one` and `reg_pos_two`). 
-    Else, if the TCP packet is entering the internal network, 
-    read both the bloom filter arrays at the computed bit positions and drop the packet if 
+    4. **TODO:** If the TCP packet is going out of the internal network and is a SYN packet,
+    set both the bloom filter arrays at the computed bit positions (`reg_pos_one` and `reg_pos_two`).
+    Else, if the TCP packet is entering the internal network,
+    read both the bloom filter arrays at the computed bit positions and drop the packet if
     either is not set.
 9. A deparser that emits the Ethernet, IPv4 and TCP headers in the right order.
 10. A `package` instantiation supplied with the parser, control, and deparser.
@@ -171,18 +171,18 @@ h3 and h1 should be blocked by the firewall.
 
 ### Food for thought
 
-You may have noticed that in this simple stateful firewall, we are adding 
-new TCP connections to the bloom filter (based on outgoing SYN packets). 
-However, we are not removing them in case of TCP connection teardown 
-(FIN packets). How would you implement the removal of TCP connections that are 
+You may have noticed that in this simple stateful firewall, we are adding
+new TCP connections to the bloom filter (based on outgoing SYN packets).
+However, we are not removing them in case of TCP connection teardown
+(FIN packets). How would you implement the removal of TCP connections that are
 no longer active?
 
-Things to consider: 
- - Can we simply set the bloom filter array bits to `0` on 
- receiving a FIN packet? What happens when there is one hash collision in 
+Things to consider:
+ - Can we simply set the bloom filter array bits to `0` on
+ receiving a FIN packet? What happens when there is one hash collision in
  the bloom filter arrays between two _active_ TCP connections?
- - How can we modify our bloom filter structure so that the deletion 
- operation can be properly supported? 
+ - How can we modify our bloom filter structure so that the deletion
+ operation can be properly supported?
 
 ### Troubleshooting
 

--- a/exercises/firewall/basic.p4
+++ b/exercises/firewall/basic.p4
@@ -74,7 +74,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -89,14 +89,14 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: lpm;
@@ -109,7 +109,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = drop();
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
@@ -133,10 +133,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/firewall/firewall.p4
+++ b/exercises/firewall/firewall.p4
@@ -108,7 +108,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -154,7 +154,7 @@ control MyIngress(inout headers hdr,
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: lpm;
@@ -184,7 +184,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = NoAction();
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()){
             ipv4_lpm.apply();
@@ -232,10 +232,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/firewall/solution/firewall.p4
+++ b/exercises/firewall/solution/firewall.p4
@@ -108,7 +108,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -154,7 +154,7 @@ control MyIngress(inout headers hdr,
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: lpm;
@@ -184,7 +184,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = NoAction();
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()){
             ipv4_lpm.apply();
@@ -238,10 +238,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/link_monitor/link_monitor.p4
+++ b/exercises/link_monitor/link_monitor.p4
@@ -138,7 +138,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -154,14 +154,14 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: lpm;
@@ -174,7 +174,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = drop();
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
@@ -240,7 +240,7 @@ control MyEgress(inout headers hdr,
             // hdr.probe_data[0].byte_cnt = ...
             // TODO: read / update the last_time_reg
             // last_time_reg.read(<val>, <index>);
-            // last_time_reg.write(<index>, <val>); 
+            // last_time_reg.write(<index>, <val>);
             // hdr.probe_data[0].last_time = ...
             // hdr.probe_data[0].cur_time = ...
         }
@@ -253,10 +253,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/link_monitor/solution/link_monitor.p4
+++ b/exercises/link_monitor/solution/link_monitor.p4
@@ -138,7 +138,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -154,14 +154,14 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
         hdr.ethernet.dstAddr = dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: lpm;
@@ -174,7 +174,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = drop();
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
@@ -252,10 +252,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/load_balance/load_balance.p4
+++ b/exercises/load_balance/load_balance.p4
@@ -102,7 +102,7 @@ control MyIngress(inout headers hdr,
         mark_to_drop(standard_metadata);
     }
     action set_ecmp_select(bit<16> ecmp_base, bit<32> ecmp_count) {
-        /* TODO: hash on 5-tuple and save the hash result in meta.ecmp_select 
+        /* TODO: hash on 5-tuple and save the hash result in meta.ecmp_select
            so that the ecmp_nhop table can use it to make a forwarding decision accordingly */
     }
     action set_nhop(bit<48> nhop_dmac, bit<32> nhop_ipv4, bit<9> port) {
@@ -133,8 +133,8 @@ control MyIngress(inout headers hdr,
     }
     apply {
         /* TODO: apply ecmp_group table and ecmp_nhop table if IPv4 header is
-	 * valid and TTL hasn't reached zero
-	 */
+         * valid and TTL hasn't reached zero
+         */
     }
 }
 
@@ -173,10 +173,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/load_balance/solution/load_balance.p4
+++ b/exercises/load_balance/solution/load_balance.p4
@@ -59,7 +59,7 @@ parser MyParser(packet_in packet,
                 out headers hdr,
                 inout metadata meta,
                 inout standard_metadata_t standard_metadata) {
-    
+
     state start {
         transition parse_ethernet;
     }
@@ -103,14 +103,14 @@ control MyIngress(inout headers hdr,
     }
     action set_ecmp_select(bit<16> ecmp_base, bit<32> ecmp_count) {
         hash(meta.ecmp_select,
-	    HashAlgorithm.crc16,
-	    ecmp_base,
-	    { hdr.ipv4.srcAddr,
-	      hdr.ipv4.dstAddr,
+            HashAlgorithm.crc16,
+            ecmp_base,
+            { hdr.ipv4.srcAddr,
+              hdr.ipv4.dstAddr,
               hdr.ipv4.protocol,
               hdr.tcp.srcPort,
               hdr.tcp.dstPort },
-	    ecmp_count);
+            ecmp_count);
     }
     action set_nhop(bit<48> nhop_dmac, bit<32> nhop_ipv4, bit<9> port) {
         hdr.ethernet.dstAddr = nhop_dmac;
@@ -153,7 +153,7 @@ control MyIngress(inout headers hdr,
 control MyEgress(inout headers hdr,
                  inout metadata meta,
                  inout standard_metadata_t standard_metadata) {
-    
+
     action rewrite_mac(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
@@ -181,10 +181,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/mri/mri.p4
+++ b/exercises/mri/mri.p4
@@ -140,7 +140,7 @@ parser MyParser(packet_in packet,
         *   - Otherwise, transition to parse_swtrace.
         */
         transition accept;
-    }    
+    }
 }
 
 
@@ -148,7 +148,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -163,7 +163,7 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
@@ -183,7 +183,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = NoAction();
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
@@ -198,7 +198,7 @@ control MyIngress(inout headers hdr,
 control MyEgress(inout headers hdr,
                  inout metadata meta,
                  inout standard_metadata_t standard_metadata) {
-    action add_swtrace(switchID_t swid) { 
+    action add_swtrace(switchID_t swid) {
         /*
         * TODO: add logic to:
         - Increment hdr.mri.count by 1
@@ -212,21 +212,21 @@ control MyEgress(inout headers hdr,
     }
 
     table swtrace {
-        actions        = { 
+        actions        = {
             add_swtrace;
             NoAction;
         }
 
-        default_action =  NoAction();      
+        default_action =  NoAction();
     }
-    
+
     apply {
         /*
         * TODO: add logic to:
         * - If hdr.mri is valid:
         *   - Apply table swtrace
         */
-	swtrace.apply();
+        swtrace.apply();
     }
 }
 
@@ -236,10 +236,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/mri/s1-runtime.json
+++ b/exercises/mri/s1-runtime.json
@@ -33,7 +33,7 @@
         "port": 1
       }
     },
- 
+
     {
       "table": "MyIngress.ipv4_lpm",
       "match": {

--- a/exercises/mri/solution/mri.p4
+++ b/exercises/mri/solution/mri.p4
@@ -132,7 +132,7 @@ parser MyParser(packet_in packet,
             0 : accept;
             default: parse_swtrace;
         }
-    }    
+    }
 }
 
 
@@ -140,7 +140,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -155,7 +155,7 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
@@ -175,7 +175,7 @@ control MyIngress(inout headers hdr,
         size = 1024;
         default_action = NoAction();
     }
-    
+
     apply {
         if (hdr.ipv4.isValid()) {
             ipv4_lpm.apply();
@@ -190,7 +190,7 @@ control MyIngress(inout headers hdr,
 control MyEgress(inout headers hdr,
                  inout metadata meta,
                  inout standard_metadata_t standard_metadata) {
-    action add_swtrace(switchID_t swid) { 
+    action add_swtrace(switchID_t swid) {
         hdr.mri.count = hdr.mri.count + 1;
         hdr.swtraces.push_front(1);
         // According to the P4_16 spec, pushed elements are invalid, so we need
@@ -202,18 +202,18 @@ control MyEgress(inout headers hdr,
         hdr.swtraces[0].qdepth = (qdepth_t)standard_metadata.deq_qdepth;
 
         hdr.ipv4.ihl = hdr.ipv4.ihl + 2;
-        hdr.ipv4_option.optionLength = hdr.ipv4_option.optionLength + 8; 
-	hdr.ipv4.totalLen = hdr.ipv4.totalLen + 8;
+        hdr.ipv4_option.optionLength = hdr.ipv4_option.optionLength + 8;
+        hdr.ipv4.totalLen = hdr.ipv4.totalLen + 8;
     }
 
     table swtrace {
-        actions = { 
-	    add_swtrace; 
-	    NoAction; 
+        actions = {
+            add_swtrace;
+            NoAction;
         }
-        default_action = NoAction();      
+        default_action = NoAction();
     }
-    
+
     apply {
         if (hdr.mri.isValid()) {
             swtrace.apply();
@@ -227,10 +227,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,
@@ -255,7 +255,7 @@ control MyDeparser(packet_out packet, in headers hdr) {
         packet.emit(hdr.ipv4);
         packet.emit(hdr.ipv4_option);
         packet.emit(hdr.mri);
-        packet.emit(hdr.swtraces);                 
+        packet.emit(hdr.swtraces);
     }
 }
 

--- a/exercises/p4runtime/README.md
+++ b/exercises/p4runtime/README.md
@@ -2,13 +2,13 @@
 
 ## Introduction
 
-In this exercise, we will be using P4Runtime to send flow entries to the 
+In this exercise, we will be using P4Runtime to send flow entries to the
 switch instead of using the switch's CLI. We will be building on the same P4
 program that you used in the [basic_tunnel](../basic_tunnel) exercise. The
 P4 program has been renamed to `advanced_tunnel.p4` and has been augmented
 with two counters (`ingressTunnelCounter`, `egressTunnelCounter`) and
 two new actions (`myTunnel_ingress`, `myTunnel_egress`).
- 
+
 You will use the starter program, `mycontroller.py`, and a few helper
 libraries in the `p4runtime_lib` directory to create the table entries
 necessary to tunnel traffic between host 1 and 2.
@@ -43,7 +43,7 @@ are working as expected.
    ```
    Because there are no rules on the switches, you should **not** receive any
    replies yet. You should leave the ping running in this shell.
-   
+
 3. Open another shell and run the starter code:
    ```bash
    cd ~/tutorials/exercises/p4runtime
@@ -56,7 +56,7 @@ are working as expected.
    ```
     s1 ingressTunnelCounter 100: 2 packets
    ```
-   The other counters should remain at zero. 
+   The other counters should remain at zero.
 
 4. Press `Ctrl-C` to the second shell to stop `mycontroller.py`
 
@@ -145,11 +145,11 @@ you will just need to run the following in your second shell:
 You should start to see ICMP replies in your Mininet prompt, and you should start to
 see the values for all counters start to increment.
 
-### Extra Credit and Food for Thought 
+### Extra Credit and Food for Thought
 
 You might notice that the rules that are printed by `mycontroller.py` contain the entity
 IDs rather than the table names. You can use the P4Info helper to translate these IDs
-into entry names. 
+into entry names.
 
 Also, you may want to think about the following:
 - What assumptions about the topology are baked into your implementation? How would you

--- a/exercises/p4runtime/advanced_tunnel.p4
+++ b/exercises/p4runtime/advanced_tunnel.p4
@@ -91,7 +91,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -110,7 +110,7 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         standard_metadata.egress_spec = port;
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
@@ -194,10 +194,10 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
+              hdr.ipv4.ihl,
               hdr.ipv4.diffserv,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,

--- a/exercises/qos/qos.p4
+++ b/exercises/qos/qos.p4
@@ -159,8 +159,8 @@ control MyEgress(inout headers hdr,
 control MyComputeChecksum(inout headers hdr, inout metadata meta) {
     apply {
         /* TODO: replace tos with diffserv and ecn */
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
               hdr.ipv4.ihl,
               hdr.ipv4.tos,

--- a/exercises/qos/solution/qos.p4
+++ b/exercises/qos/solution/qos.p4
@@ -207,9 +207,9 @@ control MyIngress(inout headers hdr,
         if (hdr.ipv4.isValid()) {
             if (hdr.ipv4.protocol == IP_PROTOCOLS_UDP) {
                 expedited_forwarding();
-	    }
+            }
             else if (hdr.ipv4.protocol == IP_PROTOCOLS_TCP) {
-	        voice_admit();
+                voice_admit();
             }
             ipv4_lpm.apply();
         }
@@ -232,12 +232,12 @@ control MyEgress(inout headers hdr,
 
 control MyComputeChecksum(inout headers hdr, inout metadata meta) {
      apply {
-	update_checksum(
-	    hdr.ipv4.isValid(),
+        update_checksum(
+            hdr.ipv4.isValid(),
             { hdr.ipv4.version,
-	      hdr.ipv4.ihl,
-	      hdr.ipv4.diffserv,
-	      hdr.ipv4.ecn,
+              hdr.ipv4.ihl,
+              hdr.ipv4.diffserv,
+              hdr.ipv4.ecn,
               hdr.ipv4.totalLen,
               hdr.ipv4.identification,
               hdr.ipv4.flags,

--- a/exercises/source_routing/s1-runtime.json
+++ b/exercises/source_routing/s1-runtime.json
@@ -3,4 +3,4 @@
   "p4info": "build/source_routing.p4.p4info.txt",
   "bmv2_json": "build/source_routing.json",
   "table_entries": [ ]
-} 
+}

--- a/exercises/source_routing/s2-runtime.json
+++ b/exercises/source_routing/s2-runtime.json
@@ -3,4 +3,4 @@
   "p4info": "build/source_routing.p4.p4info.txt",
   "bmv2_json": "build/source_routing.json",
   "table_entries": [ ]
-} 
+}

--- a/exercises/source_routing/s3-runtime.json
+++ b/exercises/source_routing/s3-runtime.json
@@ -3,4 +3,4 @@
   "p4info": "build/source_routing.p4.p4info.txt",
   "bmv2_json": "build/source_routing.json",
   "table_entries": [ ]
-} 
+}

--- a/exercises/source_routing/solution/source_routing.p4
+++ b/exercises/source_routing/solution/source_routing.p4
@@ -59,7 +59,7 @@ parser MyParser(packet_in packet,
                 out headers hdr,
                 inout metadata meta,
                 inout standard_metadata_t standard_metadata) {
-    
+
     state start {
         transition parse_ethernet;
     }
@@ -92,7 +92,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -108,7 +108,7 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action srcRoute_nhop() {
         standard_metadata.egress_spec = (bit<9>)hdr.srcRoutes[0].port;
         hdr.srcRoutes.pop_front(1);
@@ -121,7 +121,7 @@ control MyIngress(inout headers hdr,
     action update_ttl(){
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     apply {
         if (hdr.srcRoutes[0].isValid()){
             if (hdr.srcRoutes[0].bos == 1){
@@ -133,7 +133,7 @@ control MyIngress(inout headers hdr,
             }
         }else{
             drop();
-        } 
+        }
     }
 }
 

--- a/exercises/source_routing/source_routing.p4
+++ b/exercises/source_routing/source_routing.p4
@@ -60,7 +60,7 @@ parser MyParser(packet_in packet,
                 inout metadata meta,
                 inout standard_metadata_t standard_metadata) {
 
-    
+
     state start {
         transition parse_ethernet;
     }
@@ -96,7 +96,7 @@ parser MyParser(packet_in packet,
 ************   C H E C K S U M    V E R I F I C A T I O N   *************
 *************************************************************************/
 
-control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
     apply {  }
 }
 
@@ -112,10 +112,10 @@ control MyIngress(inout headers hdr,
     action drop() {
         mark_to_drop(standard_metadata);
     }
-    
+
     action srcRoute_nhop() {
         /*
-         * TODO: set standard_metadata.egress_spec 
+         * TODO: set standard_metadata.egress_spec
          * to the port in hdr.srcRoutes[0] and
          * pop an entry from hdr.srcRoutes
          */
@@ -128,7 +128,7 @@ control MyIngress(inout headers hdr,
     action update_ttl(){
         hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
     }
-    
+
     apply {
         if (hdr.srcRoutes[0].isValid()){
             /*
@@ -143,7 +143,7 @@ control MyIngress(inout headers hdr,
             }
         }else{
             drop();
-        } 
+        }
     }
 }
 

--- a/utils/cheat_sheet_src/main.tex
+++ b/utils/cheat_sheet_src/main.tex
@@ -7,7 +7,7 @@
 
 \documentclass{article}
 
-\usepackage{fontspec} 
+\usepackage{fontspec}
 \setmainfont{Utopia}
 \setsansfont{Free Helvetian}
 \setmonofont{Liberation Mono}
@@ -55,7 +55,7 @@
   basicstyle=\small\ttfamily, % Global Code Style
   captionpos=b, % Position of the Caption (t for top, b for bottom)
   extendedchars=true, % Allows 256 instead of 128 ASCII characters
-  tabsize=2, % number of spaces indented when discovering a tab 
+  tabsize=2, % number of spaces indented when discovering a tab
   columns=fixed, % make all characters equal width
   keepspaces=true, % does not ignore spaces to fit width, convert tabs to spaces
   showstringspaces=false, % lets spaces in strings appear as real spaces
@@ -88,7 +88,7 @@
     rectangle, rounded corners, inner sep=10pt, inner ysep=10pt]
 \tikzstyle{fancytitle} =[fill=black, text=white, font=\bfseries]
 \tikzstyle{mybox2} = [draw=black, fill=white, very thick, rectangle split,
-    rectangle split parts=2, 
+    rectangle split parts=2,
     rounded corners, inner sep=10pt, inner ysep=10pt]
 \tikzstyle{fancytitle2} =[fill=black, text=white, font=\bfseries]
 

--- a/utils/cheat_sheet_src/src/architecture.txt
+++ b/utils/cheat_sheet_src/src/architecture.txt
@@ -3,7 +3,7 @@ extern void truncate(in bit<32> length);
 extern void resubmit<T>(in T x);
 extern void recirculate<T>(in T x);
 enum CloneType { I2E, E2I }
-extern void clone(in CloneType type, 
+extern void clone(in CloneType type,
                   in bit<32> session);
 
 // v1model pipeline elements
@@ -26,7 +26,7 @@ control Egress<H, M>(
   inout H hdr,
   inout M meta,
   inout standard_metadata_t std_meta
-);                      
+);
 control ComputeChecksum<H, M>(
   inout H hdr,
   inout M meta

--- a/utils/cheat_sheet_src/src/tables.txt
+++ b/utils/cheat_sheet_src/src/tables.txt
@@ -1,7 +1,7 @@
 table ipv4_lpm {
   key = {
     hdr.ipv4.dstAddr : lpm;
-    // standard match kinds: 
+    // standard match kinds:
     // exact, ternary, lpm
   }
   // actions that can be invoked

--- a/utils/p4apprunner.py
+++ b/utils/p4apprunner.py
@@ -264,7 +264,7 @@ def run_stf(manifest):
 
 def run_custom(manifest):
     output_file = run_compile_bmv2(manifest)
-    python_path = 'PYTHONPATH=$PYTHONPATH:/scripts/mininet/'    
+    python_path = 'PYTHONPATH=$PYTHONPATH:/scripts/mininet/'
     script_args = []
     script_args.append('--behavioral-exe "%s"' % 'simple_switch')
     script_args.append('--json "%s"' % output_file)

--- a/vm-ubuntu-20.04/p4.vim
+++ b/vm-ubuntu-20.04/p4.vim
@@ -34,7 +34,7 @@ syn keyword p4ObjectAttributeKeyword  counters meters
 syn keyword p4ObjectKeyword           const in out inout
 
 
-syn keyword p4Annotation              @name @tableonly @defaultonly 
+syn keyword p4Annotation              @name @tableonly @defaultonly
 syn keyword p4Annotation              @globalname @atomic @hidden
 
 
@@ -53,7 +53,7 @@ syn keyword p4Type           bit bool int varbit void error
 
 " Integer Literals
 
-syn match   p4Int            '[0-9][0-9_]*'  
+syn match   p4Int            '[0-9][0-9_]*'
 syn match   p4Indentifier    '[A-Za-z_][A-Za-z0-9_]*'
 syn match   p4HexadecimalInt '0[Xx][0-9a-fA-F]\+'
 syn match   p4DecimalInt     '0[dD][0-9_]\+'
@@ -72,7 +72,7 @@ syn keyword p4Primitive     isValid setValid setInvalid
 syn keyword p4Primitive     hit action_run
 " Packet_in methods
 syn keyword p4Primitive     extract lookahead advance length
-" Packet_out methods  
+" Packet_out methods
 syn keyword p4Primitive     emit
 " Known parser states
 syn keyword p4Primitive     accept reject
@@ -91,7 +91,7 @@ syn keyword p4Constant      OverwritingHeader HeaderTooShort ParserTiimeout
 " Boolean
 syn keyword p4Boolean       false true
 
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""" 
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Apply highlight groups to syntax groups defined above
 " For version 5.7 and earlier: only when not done already
 " For version 5.8 and later: only when an item doesn't have highlighting yet

--- a/vm-ubuntu-20.04/p4_16-mode.el
+++ b/vm-ubuntu-20.04/p4_16-mode.el
@@ -29,19 +29,19 @@
 ;; Syntactic HighLighting
 
 ;; Main keywors (declarations and operators)
-(setq p4_16-keywords 
+(setq p4_16-keywords
       '("action" "apply"
         "control"
-        "default" 
+        "default"
         "else" "enum" "extern" "exit"
         "header" "header_union"
         "if"
         "match_kind"
-        "package" "parser" 
+        "package" "parser"
         "return"
         "select" "state" "struct" "switch"
         "table"  "transition" "tuple" "typedef"
-        "verify" 
+        "verify"
         ))
 
 (setq p4_16-annotations
@@ -50,7 +50,7 @@
 
 (setq p4_16-attributes
       '("const" "in" "inout" "out"
-        ;; Tables 
+        ;; Tables
         "key" "actions" "default_action" "entries" "implementation"
         "counters" "meters"
         ))
@@ -97,7 +97,7 @@
         ))
 
 (setq p4_16-cpp
-      '("#include" 
+      '("#include"
         "#define" "#undef"
         "#if" "#ifdef" "#ifndef"
         "#elif" "#else"
@@ -209,7 +209,7 @@
   (set-syntax-table p4_16-mode-syntax-table)
   (use-local-map p4_16-mode-map)
   (set (make-local-variable 'font-lock-defaults) '(p4_16-font-lock-keywords))
-  (set (make-local-variable 'indent-line-function) 'p4_16-indent-line)  
+  (set (make-local-variable 'indent-line-function) 'p4_16-indent-line)
   (setq major-mode 'p4_16-mode)
   (setq mode-name "P4_16")
   (setq imenu-generic-expression p4_16-imenu-generic-expression)

--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -11,15 +11,15 @@ Vagrant.configure(2) do |config|
     vb.memory = 2048
     vb.cpus = 2
     vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
-    vb.customize ["storageattach", :id, 
-                "--storagectl", "IDE Controller", 
-                "--port", "0", "--device", "0", 
-                "--type", "dvddrive", 
-                "--medium", "emptydrive"]    
+    vb.customize ["storageattach", :id,
+                "--storagectl", "IDE Controller",
+                "--port", "0", "--device", "0",
+                "--type", "dvddrive",
+                "--medium", "emptydrive"]
     vb.customize ["modifyvm", :id, "--vram", "32"]
 
   end
-  config.vm.synced_folder '.', '/vagrant', disabled: true  
+  config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.hostname = "p4"
   config.vm.provision "file", source: "p4-logo.png",   destination: "/home/vagrant/p4-logo.png"
   config.vm.provision "file", source: "p4_16-mode.el", destination: "/home/vagrant/p4_16-mode.el"

--- a/vm/p4.vim
+++ b/vm/p4.vim
@@ -34,7 +34,7 @@ syn keyword p4ObjectAttributeKeyword  counters meters
 syn keyword p4ObjectKeyword           const in out inout
 
 
-syn keyword p4Annotation              @name @tableonly @defaultonly 
+syn keyword p4Annotation              @name @tableonly @defaultonly
 syn keyword p4Annotation              @globalname @atomic @hidden
 
 
@@ -53,7 +53,7 @@ syn keyword p4Type           bit bool int varbit void error
 
 " Integer Literals
 
-syn match   p4Int            '[0-9][0-9_]*'  
+syn match   p4Int            '[0-9][0-9_]*'
 syn match   p4Indentifier    '[A-Za-z_][A-Za-z0-9_]*'
 syn match   p4HexadecimalInt '0[Xx][0-9a-fA-F]\+'
 syn match   p4DecimalInt     '0[dD][0-9_]\+'
@@ -72,7 +72,7 @@ syn keyword p4Primitive     isValid setValid setInvalid
 syn keyword p4Primitive     hit action_run
 " Packet_in methods
 syn keyword p4Primitive     extract lookahead advance length
-" Packet_out methods  
+" Packet_out methods
 syn keyword p4Primitive     emit
 " Known parser states
 syn keyword p4Primitive     accept reject
@@ -91,7 +91,7 @@ syn keyword p4Constant      OverwritingHeader HeaderTooShort ParserTiimeout
 " Boolean
 syn keyword p4Boolean       false true
 
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""" 
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Apply highlight groups to syntax groups defined above
 " For version 5.7 and earlier: only when not done already
 " For version 5.8 and later: only when an item doesn't have highlighting yet

--- a/vm/p4_16-mode.el
+++ b/vm/p4_16-mode.el
@@ -29,19 +29,19 @@
 ;; Syntactic HighLighting
 
 ;; Main keywors (declarations and operators)
-(setq p4_16-keywords 
+(setq p4_16-keywords
       '("action" "apply"
         "control"
-        "default" 
+        "default"
         "else" "enum" "extern" "exit"
         "header" "header_union"
         "if"
         "match_kind"
-        "package" "parser" 
+        "package" "parser"
         "return"
         "select" "state" "struct" "switch"
         "table"  "transition" "tuple" "typedef"
-        "verify" 
+        "verify"
         ))
 
 (setq p4_16-annotations
@@ -50,7 +50,7 @@
 
 (setq p4_16-attributes
       '("const" "in" "inout" "out"
-        ;; Tables 
+        ;; Tables
         "key" "actions" "default_action" "entries" "implementation"
         "counters" "meters"
         ))
@@ -97,7 +97,7 @@
         ))
 
 (setq p4_16-cpp
-      '("#include" 
+      '("#include"
         "#define" "#undef"
         "#if" "#ifdef" "#ifndef"
         "#elif" "#else"
@@ -209,7 +209,7 @@
   (set-syntax-table p4_16-mode-syntax-table)
   (use-local-map p4_16-mode-map)
   (set (make-local-variable 'font-lock-defaults) '(p4_16-font-lock-keywords))
-  (set (make-local-variable 'indent-line-function) 'p4_16-indent-line)  
+  (set (make-local-variable 'indent-line-function) 'p4_16-indent-line)
   (setq major-mode 'p4_16-mode)
   (setq mode-name "P4_16")
   (setq imenu-generic-expression p4_16-imenu-generic-expression)

--- a/vm/user-bootstrap.sh
+++ b/vm/user-bootstrap.sh
@@ -3,7 +3,7 @@
 # Print script commands and exit on errors.
 set -xe
 
-#Src 
+#Src
 BMV2_COMMIT="b447ac4c0cfd83e5e72a3cc6120251c1e91128ab"  # August 10, 2019
 PI_COMMIT="41358da0ff32c94fa13179b9cee0ab597c9ccbcc"    # August 10, 2019
 P4C_COMMIT="69e132d0d663e3408d740aaf8ed534ecefc88810"   # August 10, 2019
@@ -128,7 +128,7 @@ sudo ln -s /usr/share/emacs/site-lisp/p4_16-mode.el /home/p4/.emacs.d/p4_16-mode
 sudo chown -R p4:p4 /home/p4/.emacs.d/
 
 # --- Vim --- #
-cd ~  
+cd ~
 mkdir .vim
 cd .vim
 mkdir ftdetect


### PR DESCRIPTION
This pull request is rebased on top of https://github.com/p4lang/tutorials/pull/452. It removes trailing whitespace in many files in the repository. The clean up changes have been mostly auto-generated with:
```
find . -type f -print0 | xargs -0 perl -pi -e 's/ +$//'
```