### PR TITLE
Replace git:// with https://

### DIFF
--- a/vm-ubuntu-20.04/user-common-bootstrap.sh
+++ b/vm-ubuntu-20.04/user-common-bootstrap.sh
@@ -4,7 +4,7 @@
 set -xe
 
 # --- Mininet --- #
-git clone git://github.com/mininet/mininet mininet
+git clone https://github.com/mininet/mininet mininet
 cd mininet
 PATCH_DIR="${HOME}/patches"
 patch -p1 < "${PATCH_DIR}/mininet-dont-install-python2.patch" || echo "Errors while attempting to patch mininet, but continuing anyway ..."

--- a/vm-ubuntu-20.04/user-dev-bootstrap.sh
+++ b/vm-ubuntu-20.04/user-dev-bootstrap.sh
@@ -213,7 +213,7 @@ cd ../..
 find /usr/lib /usr/local $HOME/.local | sort > $HOME/usr-local-6-after-p4c.txt
 
 # --- PTF --- #
-git clone git://github.com/p4lang/ptf
+git clone https://github.com/p4lang/ptf
 cd ptf
 git checkout ${PTF_COMMIT}
 sudo python3 setup.py install


### PR DESCRIPTION
Error - The unauthenticated git protocol on port 9418 is no longer supported.
Solution - Replace git:// with https://
Explanation - https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git