### PR TITLE
Switch to vmsvga for graphics controller

### DIFF
--- a/vm-ubuntu-20.04/Vagrantfile
+++ b/vm-ubuntu-20.04/Vagrantfile
@@ -51,6 +51,7 @@ Vagrant.configure(2) do |config|
       "--medium", "emptydrive"
     ]
     vb.customize ["modifyvm", :id, "--vram", "32"]
+    vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
   end
 
 end


### PR DESCRIPTION
VirtualBox 6.0 shows an error about the settings for the graphics
controller in the GUI, and there are also issues where the virtualbox
machine hangs and does not finish booting. Changing to the vmsvga
driver resolves this.

This probably fixes issues like #282