### PR TITLE
[user-bootstrap.sh]: Fix a wrong link of mininet

### DIFF
--- a/vm/user-bootstrap.sh
+++ b/vm/user-bootstrap.sh
@@ -14,7 +14,7 @@ GRPC_COMMIT="v1.3.2"
 NUM_CORES=`grep -c ^processor /proc/cpuinfo`
 
 # --- Mininet --- #
-git clone git://github.com/mininet/mininet mininet
+git clone https://github.com/mininet/mininet mininet
 sudo ./mininet/util/install.sh -nwv
 
 # --- Protobuf --- #


### PR DESCRIPTION
Get following error when create the tutorial environment.

```
    p4-tutorial: + git clone git://github.com/mininet/mininet mininet
    p4-tutorial: Cloning into 'mininet'...
    p4-tutorial: fatal: unable to connect to github.com:
    p4-tutorial: github.com[0: 20.27.177.113]: errno=Connection timed out
    p4-tutorial:
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

May the wrong link cause this error.