### PR TITLE
Remove part of README install instructions that are obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,6 @@ To build the virtual machine:
 
 You will need the script to execute to completion before you can see the `p4` login on your virtual machine's GUI. In some cases, the `vagrant up` command brings up only the default `vagrant` login with the password `vagrant`. Dependencies may or may not have been installed for you to proceed with running P4 programs. Please refer the [existing issues](https://github.com/p4lang/tutorials/issues) to help fix your problem or create a new one if your specific problem isn't addressed there.
 
-To install dependencies by hand, please reference the [vm-ubuntu-20.04](./vm-ubuntu-20.04) installation scripts.
-They contain the dependencies, versions, and installation procedure.
-You should be able to run them directly on an Ubuntu 16.04 machine:
-- `sudo ./root-bootstrap.sh`
-- `sudo ./user-bootstrap.sh`
-
 
 # Older tutorials
 


### PR DESCRIPTION
They refer to bash script names that do not exist in the vm-ubuntu-20.04 directory, and it is not straightforward and quick to update those instructions to use scripts in the vm-ubuntu-20.04 directory without making a fair number of changes, and probably several hours of testing those changes, that I am not prepared to make any time soon.

The instructions _might_ be correct for the vm directory when starting with an Ubuntu 16.04 Linux system, but that version of Ubuntu is no longer supported, and I do not think we should be recommending its use.