### PR TITLE
Update advanced_tunnel.p4 to P4~16 format

### DIFF
--- a/exercises/p4runtime/advanced_tunnel.p4
+++ b/exercises/p4runtime/advanced_tunnel.p4
@@ -104,8 +104,8 @@ control MyIngress(inout headers hdr,
                   inout metadata meta,
                   inout standard_metadata_t standard_metadata) {
 
-    counter(MAX_TUNNEL_ID, CounterType.packets_and_bytes) ingressTunnelCounter;
-    counter(MAX_TUNNEL_ID, CounterType.packets_and_bytes) egressTunnelCounter;
+    Counter(MAX_TUNNEL_ID, CounterType.Both) ingressTunnelCounter;
+    Counter(MAX_TUNNEL_ID, CounterType.Both) egressTunnelCounter;
 
     action drop() {
         mark_to_drop(standard_metadata);


### PR DESCRIPTION
During my reading of the [P4~16 Language Specification](https://p4.org/p4-spec/docs/P4-16-v-1.2.3.html) I wasn't understanding why the counters were written in this way

``` 
counter(MAX_TUNNEL_ID, CounterType.packets_and_bytes) ingressTunnelCounter;
counter(MAX_TUNNEL_ID, CounterType.packets_and_bytes) egressTunnelCounter;
```

And because of that I wetn searching and found [P4~14 Language Specification - page 27](https://p4.org/p4-spec/p4-14/v1.0.5/tex/p4.pdf#page=27) that explained the used format.

This meaning that it could be updated to the new P4~16 format, soo that is what I did :)

```
Counter(MAX_TUNNEL_ID, CounterType.Both) ingressTunnelCounter;
Counter(MAX_TUNNEL_ID, CounterType.Both) egressTunnelCounter;
```

Hope it helps! I'm loving learning P4!