### PR TITLE
Add support of pakcetio

### DIFF
--- a/utils/p4runtime_switch.py
+++ b/utils/p4runtime_switch.py
@@ -89,6 +89,10 @@ class P4RuntimeSwitch(P4Switch):
             P4Switch.device_id += 1
         self.nanomsg = "ipc:///tmp/bm-{}-log.ipc".format(self.device_id)
 
+        self.cpu_port = None
+        if "cpu_port" in kwargs:
+            self.cpu_port = kwargs["cpu_port"]
+
 
     def check_switch_started(self, pid):
         for _ in range(SWITCH_START_TIMEOUT * 2):
@@ -122,8 +126,11 @@ class P4RuntimeSwitch(P4Switch):
             args.append('--thrift-port ' + str(self.thrift_port))
         if self.grpc_port:
             args.append("-- --grpc-server-addr 0.0.0.0:" + str(self.grpc_port))
+        if self.cpu_port:
+            args.append("--cpu-port " + str(self.cpu_port))
         cmd = ' '.join(args)
         info(cmd + "\n")
+        print(cmd + "\n")
 
 
         pid = None
@@ -135,4 +142,3 @@ class P4RuntimeSwitch(P4Switch):
             error("P4 switch {} did not start correctly.\n".format(self.name))
             exit(1)
         info("P4 switch {} has been started.\n".format(self.name))
-

--- a/utils/run_exercise.py
+++ b/utils/run_exercise.py
@@ -91,7 +91,10 @@ class ExerciseTopo(Topo):
             else:
                 # add default switch
                 switchClass = None
-            self.addSwitch(sw, log_file="%s/%s.log" %(log_dir, sw), cls=switchClass)
+            if "cpu_port" in params:
+                self.addSwitch(sw, log_file="%s/%s.log" %(log_dir, sw), cpu_port=params["cpu_port"], cls=switchClass)
+            else:
+                self.addSwitch(sw, log_file="%s/%s.log" %(log_dir, sw), cls=switchClass)
 
         for link in host_links:
             host_name = link['node1']
@@ -385,4 +388,3 @@ if __name__ == '__main__':
                               args.switch_json, args.behavioral_exe, args.quiet)
 
     exercise.run_exercise()
-


### PR DESCRIPTION
By default, when executing the `make` command in the tutorial exercise, the cpu port option in bmv2 is not provided, rendering the packet in function unusable. I have added a parser option to parse the JSON parameter in the `topology.json` file to enable the CPU port for the switch. An example of the CPU port option is as follows:

```json
"switches": {
    "s1": {
        "runtime_json": "sig-topo/s1-runtime.json",
        "cpu_port": 255
    }
}
```