### PR TITLE
Correct an error command in the tutorial documentation

### DIFF
--- a/exercises/calc/README.md
+++ b/exercises/calc/README.md
@@ -33,7 +33,7 @@ you to test your calculator. You can run the driver program directly
 from the Mininet command prompt:
 
 ```
-mininet> h1 python calc.py
+mininet> h1 python3 calc.py
 >
 ```
 


### PR DESCRIPTION
When I was implementing the “calc” P4 experiment, I correctly wrote the calc.p4 code. After entering the command `make`, the code was successfully compiled and the mininet CLI appeared. However, when I entered the command `h1 python calc.py`, it didn't work. It prompted that `bash: python: command not found`.
I used the recommended image with the environment already configured by your official team. At first, I thought there might be a problem with the python environment. After various debugging and searching, I found that the version of python is 3.8.5, which means there is no problem with the Python environment. I also found the final solution: the command should be changed to `h1 python3 calc.py`. This way, my calculator program could run successfully.
It seems like a simple problem, but for beginners like me in P4 and those unfamiliar with Python, it could cause a lot of confusion. Solving this problem can help more beginners focus more on the P4 program itself.