### PR TITLE
[Minor Fixes] commented out command 

### DIFF
--- a/exercises/calc/README.md
+++ b/exercises/calc/README.md
@@ -34,7 +34,6 @@ from the Mininet command prompt:
 
 ```
 mininet> h1 python3 calc.py
->
 ```
 
 3. The driver program will provide a new prompt, at which you can type
@@ -48,7 +47,6 @@ you should see an error message.
 ```
 > 1+1
 Didn't receive response
->
 ```
 
 ## Step 2: Implement Calculator
@@ -103,7 +101,6 @@ correct result:
 ```
 > 1+1
 2
->
 ```
 
 ## Relevant Documentation

--- a/exercises/calc/README.md
+++ b/exercises/calc/README.md
@@ -34,6 +34,7 @@ from the Mininet command prompt:
 
 ```
 mininet> h1 python3 calc.py
+>
 ```
 
 3. The driver program will provide a new prompt, at which you can type
@@ -47,6 +48,7 @@ you should see an error message.
 ```
 > 1+1
 Didn't receive response
+>
 ```
 
 ## Step 2: Implement Calculator
@@ -101,6 +103,7 @@ correct result:
 ```
 > 1+1
 2
+>
 ```
 
 ## Relevant Documentation

--- a/vm-ubuntu-20.04/README.md
+++ b/vm-ubuntu-20.04/README.md
@@ -87,7 +87,8 @@ version of source code used to create that image already included in
 the home directory of the `vagrant` user account:
 
 ```bash
-# git clone --recursive https://github.com/p4lang/p4c
+# for Release VM image only 
+git clone --recursive https://github.com/p4lang/p4c
 ```
 
 The following steps are common for both Release and Development VM


### PR DESCRIPTION
## Current
- The command to clone the repo is commented out [Reference](https://github.com/p4lang/tutorials/tree/master/vm-ubuntu-20.04#p4c-testing-results)
![image](https://github.com/p4lang/tutorials/assets/100958893/faeb336d-bbfc-4fe2-8170-958c0a97dbb7)

## Changes
- fixed commented out command
- added appropriate comment for "cloning in release version only"
![image](https://github.com/p4lang/tutorials/assets/100958893/0c0ae86f-11e2-42d4-8c6c-fc8ed55963b3)
