### PR TITLE
[Docs] Added Multicast to exercises list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ you get started with P4 programming, organized into several modules:
 
 4. Advanced Behavior
 * [Multicasting](./exercises/multicast)
+  <br> <small>This exercise involves writing a P4 program to enable a network switch to multicast packets to multiple output ports based on the destination MAC address. It requires the implementation of logic to handle multicast packets, including defining actions for packet forwarding and configuring the control plane to manage packet processing rules. Through practical implementation and testing in a Mininet environment, participants learn to enhance network traffic management and efficiency through multicast communication.</small>
+
 * [Source Routing](./exercises/source_routing)
 * [Calculator](./exercises/calc)
 * [Load Balancing](./exercises/load_balance)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ you get started with P4 programming, organized into several modules:
 
 4. Advanced Behavior
 * [Multicasting](./exercises/multicast)
-  <br> <small>This exercise involves writing a P4 program to enable a network switch to multicast packets to multiple output ports based on the destination MAC address. It requires the implementation of logic to handle multicast packets, including defining actions for packet forwarding and configuring the control plane to manage packet processing rules. Through practical implementation and testing in a Mininet environment, participants learn to enhance network traffic management and efficiency through multicast communication.</small>
-
 * [Source Routing](./exercises/source_routing)
 * [Calculator](./exercises/calc)
 * [Load Balancing](./exercises/load_balance)

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ you get started with P4 programming, organized into several modules:
 * [Multi-Hop Route Inspection](./exercises/mri)
 
 4. Advanced Behavior
-* [Multicasting](./exercises/multicast)
 * [Source Routing](./exercises/source_routing)
 * [Calculator](./exercises/calc)
 * [Load Balancing](./exercises/load_balance)
 * [Quality of Service](./exercises/qos)
+* [Multicasting](./exercises/multicast)
 
 5. Stateful Packet Processing
 * [Firewall](./exercises/firewall)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ you get started with P4 programming, organized into several modules:
 * [Multi-Hop Route Inspection](./exercises/mri)
 
 4. Advanced Behavior
+* [Multicasting](./exercises/multicast)
 * [Source Routing](./exercises/source_routing)
 * [Calculator](./exercises/calc)
 * [Load Balancing](./exercises/load_balance)


### PR DESCRIPTION
## Current 
[Implementing Multicast ](https://github.com/p4lang/tutorials/tree/master/exercises/multicast#implementing-multicast) is not listed in the [modules list](https://github.com/p4lang/tutorials#introduction)

## Changes 
Added Multicast to modules list 

## Tasks Before merging  
- [x] Discuss the sequence of multicast in list 
- [ ] Update "Next Steps" Assignments in exercise directory accordingly 