### PR TITLE
Reordered the sequence in "Next Steps" Section based on modules list

### DIFF
--- a/exercises/basic/README.md
+++ b/exercises/basic/README.md
@@ -170,6 +170,12 @@ these instances:
 make stop
 ```
 
+## Next Steps
+
+Congratulations, your implementation works! Move onto the next assignment
+[Basic Tunneling](../basic_tunnel)
+
+
 ## Relevant Documentation
 
 The documentation for P4_16 and P4Runtime is available [here](https://p4.org/specs/)

--- a/exercises/calc/README.md
+++ b/exercises/calc/README.md
@@ -106,6 +106,12 @@ correct result:
 >
 ```
 
+## Next Steps
+
+Congratulations, your implementation works! Move on to
+[Load Balancing](../load_balance).
+
+
 ## Relevant Documentation
 
 The documentation for P4_16 and P4Runtime is available [here](https://p4.org/specs/)

--- a/exercises/ecn/README.md
+++ b/exercises/ecn/README.md
@@ -190,6 +190,12 @@ these instances:
 ```bash
 make stop
 ```
+
+## Next Steps
+
+Congratulations, your implementation works! Move onto the next assignment
+[Multi-Hop Route Inspection](../mri)
+
 ## Relevant Documentation
 
 The documentation for P4_16 and P4Runtime is available [here](https://p4.org/specs/)

--- a/exercises/firewall/README.md
+++ b/exercises/firewall/README.md
@@ -213,6 +213,11 @@ these instances:
 make stop
 ```
 
+## Next Steps
+
+Congratulations, your implementation works! Move on to [Link Monitoring](../link_monitor).
+
+
 ## Relevant Documentation
 
 The documentation for P4_16 and P4Runtime is available [here](https://p4.org/specs/)

--- a/exercises/load_balance/README.md
+++ b/exercises/load_balance/README.md
@@ -129,7 +129,7 @@ mn -c
 
 ## Next Steps
 
-Congratulations, your implementation works! Move on to [Multi-Hop Route Inspection](../mri).
+Congratulations, your implementation works! Move on to [Quality of Service](../qos).
 
 ## Relevant Documentation
 

--- a/exercises/multicast/README.md
+++ b/exercises/multicast/README.md
@@ -155,6 +155,11 @@ these instances:
 make stop
 ```
 
+## Next Steps
+
+Congratulations, your implementation works! Move on to [Firewall](../firewall).
+
+
 ## Relevant Documentation
 
 The documentation for P4_16 and P4Runtime is available [here](https://p4.org/specs/)

--- a/exercises/p4runtime/README.md
+++ b/exercises/p4runtime/README.md
@@ -184,7 +184,7 @@ solution/my_controller.py
 ## Next Steps
 
 Congratulations, your implementation works! Move onto the next assignment
-[mri](../mri)!
+[Explicit Congestion Notification](../ecn)
 
 
 ## Relevant Documentation

--- a/exercises/qos/README.md
+++ b/exercises/qos/README.md
@@ -165,6 +165,11 @@ these instances:
 make stop
 ```
 
+## Next Steps
+
+Congratulations, your implementation works! Move on to [Multicasting](../multicast).
+
+
 ## Relevant Documentation
 
 The documentation for P4_16 and P4Runtime is available [here](https://p4.org/specs/)

--- a/exercises/source_routing/README.md
+++ b/exercises/source_routing/README.md
@@ -144,7 +144,7 @@ mn -c
 ## Next Steps
 
 Congratulations, your implementation works! Move on to
-[Load Balance](../load_balance).
+[Calculator](../calc).
 
 
 ## Relevant Documentation


### PR DESCRIPTION
# In favour of 
- #551

## Current 
- Sequence of tutorials based on [Next Steps](https://github.com/p4lang/tutorials/tree/master/exercises/basic_tunnel#next-steps)  Section in `basic_tunnel` Exercise.

![image](https://github.com/p4lang/tutorials/assets/100958893/a889e4ff-5287-4a4b-8cd7-76bfe8c678ae)

## Changes 
- Updated the sequence based on [module sequence in README ](https://github.com/AdarshRawat1/P4-tutorials/tree/Docs-improvement-4?tab=readme-ov-file#introduction)

![image](https://github.com/p4lang/tutorials/assets/100958893/e13cf102-fe56-4594-9443-674cd3797970)

## Result 

Results in more structured way of following the tutorials from the `next steps` section redirection . 