### PR TITLE
[FIX 🔨] Mininet Clone command

### DIFF
--- a/vm/user-bootstrap.sh
+++ b/vm/user-bootstrap.sh
@@ -14,7 +14,7 @@ GRPC_COMMIT="v1.3.2"
 NUM_CORES=`grep -c ^processor /proc/cpuinfo`
 
 # --- Mininet --- #
-git clone git://github.com/mininet/mininet mininet
+git clone https://github.com/mininet/mininet mininet
 sudo ./mininet/util/install.sh -nwv
 
 # --- Protobuf --- #


### PR DESCRIPTION
## Fixes Issue no  : #553

Fixed mininet Clone command in [VM/user-bootstrap.sh](https://github.com/p4lang/tutorials/blob/master/vm/user-bootstrap.sh#L17)

Current Command :
```bash
git clone git://github.com/mininet/mininet mininet
```
Fixed Command: Based on [latest configuration VM Ubuntu 20.04](https://github.com/p4lang/tutorials/blob/6c1b36e3cdb4440ec51399648c4dca96032ab243/vm-ubuntu-20.04/user-common-bootstrap.sh#L8) 
```bash
git clone https://github.com/mininet/mininet mininet
```

PS: 
- Is there a need to keep the current command preserved as a comment?