### PR TITLE
 [Fix🔨]Reverted description of task done in [PR #545]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ given live classes.
 Welcome to the P4 Tutorial! We've prepared a set of exercises to help
 you get started with P4 programming, organized into several modules:
 
-Sure, here's the revised structure with bullet points inside the numbered sections:
-
 1. Introduction and Language Basics
    - [Basic Forwarding](./exercises/basic)<br>
      <small>In this exercise, you'll learn to implement basic IPv4 packet forwarding using P4. By extending the provided `basic.p4` skeleton, you'll develop logic for updating MAC addresses, decrementing TTL values, and forwarding packets based on predefined rules. Through practical implementation and testing on a fat-tree topology in Mininet, you'll gain insights into designing and deploying data plane logic for network switches.</small>

--- a/exercises/basic/README.md
+++ b/exercises/basic/README.md
@@ -32,6 +32,9 @@ fields. We encourage you to take a look at it.
 > sub-directory. Feel free to compare your implementation to the
 > reference.
 
+## Prerequisite
+To ensure a smooth experience with the tutorials, it's essential to review and follow the [Obtaining required software guidelines](https://github.com/p4lang/tutorials#obtaining-required-software) to install required development tools.
+
 ## Step 1: Run the (incomplete) starter code
 
 The directory with this README also contains a skeleton P4 program,

--- a/exercises/basic/README.md
+++ b/exercises/basic/README.md
@@ -32,9 +32,6 @@ fields. We encourage you to take a look at it.
 > sub-directory. Feel free to compare your implementation to the
 > reference.
 
-## Prerequisite
-To ensure a smooth experience with the tutorials, it's essential to review and follow the [Obtaining required software guidelines](https://github.com/p4lang/tutorials#obtaining-required-software) to install required development tools.
-
 ## Step 1: Run the (incomplete) starter code
 
 The directory with this README also contains a skeleton P4 program,


### PR DESCRIPTION
## Reverted 
- Unnecessary changes in PR - #545 
![image](https://github.com/p4lang/tutorials/assets/100958893/07d5a501-2fe2-458b-a0d6-7bf32b9416c0)

## Reason
- We can directly use `bullet points or numbered section` without giving the description of task done. Therefore, simplifying the documentation.

## Fixes Issue
-  #558