### PR TITLE
Add Prerequisite section to basic exercise

### DIFF
--- a/exercises/basic/README.md
+++ b/exercises/basic/README.md
@@ -32,6 +32,9 @@ fields. We encourage you to take a look at it.
 > sub-directory. Feel free to compare your implementation to the
 > reference.
 
+## Prerequisite
+To ensure a smooth experience with the tutorials, it's essential to review and follow the [Obtaining required software guidelines](https://github.com/p4lang/tutorials#obtaining-required-software) to install required development tools.
+
 ## Step 1: Run the (incomplete) starter code
 
 The directory with this README also contains a skeleton P4 program,


### PR DESCRIPTION
## Changes 
Added a Prerequisite section containing [Obtaining required software](https://github.com/p4lang/tutorials#obtaining-required-software) guidelines to the `basic` exercise.

## Reason 
To avoid errors related to incomplete installation and environment setup.

## Closes Issue
- https://github.com/p4lang/tutorials/issues/561