### PR TITLE
Cleanup usages of simple_switch_CLI

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -150,11 +150,10 @@ In this file, the following elements are defined:
 
     * *route add*, which adds a static route to the default gateway (the switch).
     * *arp*, which manipulates the sytem ARP scache (adds an entry for the switch's MAC address).
-* **Switches**. Defines switch behavior. Three parameters can be inserted here:
+* **Switches**. Defines switch behavior. Two parameters can be inserted here:
     
     * *program*. Defines the program inserted into the switch (data plane). <u>Note</u>: If this parameter is not set, then the execution assumes the default P4 file (passed on startup).
     * *runtime_json*. Defines the path for the control plane file.
-    * *runtime_cli*. Also defines the path for the control plane file. This file is directed at actions that are only supported by the switch_cli interface (such as setting up mirroring).
     
 * **links**. Defines the links between network nodes. The following list format is used: 
     ```[Node1, Node2, Latency, Bandwidth]```, where nodes can be defined as ```<Hostname>```, for hosts, and ```<SwitchName>-<SwitchPort>``` for switches. Both *latency* and *bandwidth* are optional, where *latency* is an integer defined in milliseconds(ms) and *bandwidth* is a float defined in megabits per second (Mb/s).
@@ -236,7 +235,7 @@ class ExerciseTopo(Topo):
   #(... Omitted ...)#
 ```
 
-Below is shown how the switches are configured. Using the method *configureP4Switch* ensures the switch is created using the correct architecture, (*simple_switch* or *simple_switch_grpc*).
+Below is shown how the switches are configured. Using the method *configureP4Switch* ensures the switch is created using *simple_switch_grpc*.
 
 If no program is specified, the switch follows the default implementation.
 
@@ -306,7 +305,7 @@ def program_hosts(self):
 ```
 
 #### Programming the Switches
-Much like the hosts, the switches also have a runtime counterpart. The method *program_switches* divides execution according to the switch type (*simple_switch* or *simple_switch_grpc*) and runs the respective architecture-specific commands (Note: since the *simple_switch_grpc* extends the *simple_switch*, the configuration may make use of both cli and runtime methods). Below denotes the sub-branch for the configuration of the *simple_switch_grpc*. Most notably, this method makes use of the [control plane file](#the-control-plane-file).
+Much like the hosts, the switches also have a runtime counterpart. The method *program_switches* configures switches specifically for simple_switch_grpc, utilizing the [control plane file](#the-control-plane-file) for its configuration.
 
 ```python
 def program_switch_p4runtime(self, sw_name, sw_dict):

--- a/utils/README.md
+++ b/utils/README.md
@@ -235,7 +235,7 @@ class ExerciseTopo(Topo):
   #(... Omitted ...)#
 ```
 
-Below is shown how the switches are configured. Using the method *configureP4Switch* ensures the switch is created using *simple_switch_grpc*.
+Below is shown how the switches are configured. The method *configureP4Switch* creates the switch using *simple_switch_grpc*.
 
 If no program is specified, the switch follows the default implementation.
 

--- a/utils/run_exercise.py
+++ b/utils/run_exercise.py
@@ -282,33 +282,15 @@ class ExerciseRunner:
                 runtime_json=runtime_json
             )
 
-    def program_switch_cli(self, sw_name, sw_dict):
-        """ This method will start up the CLI and use the contents of the
-            command files as input.
-        """
-        cli = 'simple_switch_CLI'
-        # get the port for this particular switch's thrift server
-        sw_obj = self.net.get(sw_name)
-        thrift_port = sw_obj.thrift_port
-
-        cli_input_commands = sw_dict['cli_input']
-        self.logger('Configuring switch %s with file %s' % (sw_name, cli_input_commands))
-        with open(cli_input_commands, 'r') as fin:
-            cli_outfile = '%s/%s_cli_output.log'%(self.log_dir, sw_name)
-            with open(cli_outfile, 'w') as fout:
-                subprocess.Popen([cli, '--thrift-port', str(thrift_port)],
-                                 stdin=fin, stdout=fout)
-
     def program_switches(self):
-        """ This method will program each switch using the BMv2 CLI and/or
-            P4Runtime, depending if any command or runtime JSON files were
-            provided for the switches.
+        """ This method will program each switch using the BMv2 P4Runtime,
+            depending if any runtime JSON files were provided for the switches.
         """
         for sw_name, sw_dict in self.switches.items():
-            if 'cli_input' in sw_dict:
-                self.program_switch_cli(sw_name, sw_dict)
             if 'runtime_json' in sw_dict:
                 self.program_switch_p4runtime(sw_name, sw_dict)
+            else:
+                self.logger('Warning: No runtime JSON configuration provided for switch %s.' % sw_name)
 
     def program_hosts(self):
         """ Execute any commands provided in the topology.json file on each Mininet host


### PR DESCRIPTION
Issue for context: https://github.com/p4lang/tutorials/issues/99

`simple_switch_CLI` is currently [used by 4 files:](https://github.com/search?q=repo%3Ap4lang%2Ftutorials%20simple_switch_cli&type=code)
1.  [utils/run_exercise.py](https://github.com/p4lang/tutorials/blob/ee16fbde2a4c69ae66220a8112625b1b1559d61d/utils/run_exercise.py#L289)
2. [utils/p4apprunner.py](https://github.com/p4lang/tutorials/blob/ee16fbde2a4c69ae66220a8112625b1b1559d61d/utils/p4apprunner.py#L167)
3. [utils/mininet/appcontroller.py](https://github.com/p4lang/tutorials/blob/ee16fbde2a4c69ae66220a8112625b1b1559d61d/utils/mininet/appcontroller.py#L30)
4. [utils/mininet/single_switch_mininet.py](https://github.com/p4lang/tutorials/blob/ee16fbde2a4c69ae66220a8112625b1b1559d61d/utils/mininet/single_switch_mininet.py#L42)

The usage within `run_exercise.py` depends on whether the `cli_input` field is set in the switch configuration (`topology.json`). https://github.com/p4lang/tutorials/blob/ee16fbde2a4c69ae66220a8112625b1b1559d61d/utils/run_exercise.py#L308 

This field not configured in any of the topology files of any exercise in this repo, therefore it is safe to delete.  Instead, the `runtime_json` field is set for all switches. The only exception is the p4runtime exercise, where the switches are programmed using a python controller. 

I added a warning for the case that `runtime_json` is not set in the switch config to inform the user whenever a runtime configuration is missing for a switch.

In `run_exercise.py`, `simple_switch_CLI` is also [mentioned as a message](https://github.com/p4lang/tutorials/blob/ee16fbde2a4c69ae66220a8112625b1b1559d61d/utils/run_exercise.py#L348) when starting the mininet CLI. Based on the `simple_switch_CLI`  [docs](https://github.com/p4lang/behavioral-model/blob/main/docs/runtime_CLI.md), this could still be useful for someone wanting to inspect the configurations or play around with the switches at runtime.

Just to make sure everything still works, I ran all exercises and compared the results. Everything still works as expected.

Interestingly though, I also found that the `p4apprunner.py`, `appcontroller.py`, `single_switch_mininet.py` and `multi_switch_mininet.py` are not used in any exercise, nor are they referenced in any readmes/guides (I ran all exercises after deleting these files). I am unsure about their purpose so I left them untouched in this PR. @jafingerhut can you please provide context on what these files are/were used for?
