### PR TITLE
Add an example for simple_switch_CLI

### DIFF
--- a/exercises/mri/README.md
+++ b/exercises/mri/README.md
@@ -205,6 +205,22 @@ got a packet
 
 ```
 
+### Food for thought
+The maximum queue depth and queue rate of each switch can be configured using `simple_switch_CLI`. Connect to the CLI of switch `s1` using the following command on your host machine:
+```bash
+simple_switch_CLI --thrift-port 9090
+```
+
+Then, set the maximum queue depth and rate using the following commands:
+```bash
+set_queue_rate 50
+set_queue_depth 100
+```
+
+Feel free to experiment with different values for each switch and observe the changes in the MRI header.
+
+How does the `qdepth` header change with different queue depths and rates?
+
 ### Troubleshooting
 
 There are several ways that problems might manifest:

--- a/utils/README.md
+++ b/utils/README.md
@@ -154,7 +154,7 @@ In this file, the following elements are defined:
     
     * *program*. Defines the program inserted into the switch (data plane). <u>Note</u>: If this parameter is not set, then the execution assumes the default P4 file (passed on startup).
     * *runtime_json*. Defines the path for the control plane file.
-    * *runtime_cli*. Also defines the path for the control plane file. This file is directed at actions that are only supported by the switch_cli interface (such as setting up mirroring).
+    * *cli_input*. Defines the path for a command file to be executed in the switch's CLI. This file is directed at actions that are only supported by the switch_cli interface (such as setting up mirroring or setting queue rates and depths).
     
 * **links**. Defines the links between network nodes. The following list format is used: 
     ```[Node1, Node2, Latency, Bandwidth]```, where nodes can be defined as ```<Hostname>```, for hosts, and ```<SwitchName>-<SwitchPort>``` for switches. Both *latency* and *bandwidth* are optional, where *latency* is an integer defined in milliseconds(ms) and *bandwidth* is a float defined in megabits per second (Mb/s).

--- a/utils/run_exercise.py
+++ b/utils/run_exercise.py
@@ -307,8 +307,10 @@ class ExerciseRunner:
         for sw_name, sw_dict in self.switches.items():
             if 'cli_input' in sw_dict:
                 self.program_switch_cli(sw_name, sw_dict)
-            if 'runtime_json' in sw_dict:
+            elif 'runtime_json' in sw_dict:
                 self.program_switch_p4runtime(sw_name, sw_dict)
+            else:
+                self.logger('Warning: No control plane file provided for switch %s.' % sw_name)
 
     def program_hosts(self):
         """ Execute any commands provided in the topology.json file on each Mininet host


### PR DESCRIPTION
Context: PR https://github.com/p4lang/tutorials/pull/573 and issue https://github.com/p4lang/tutorials/issues/99.

- Added an example to the `mri` exercise to set queue depth and rate using the `simple_switch_CLI`
- Corrected `runtime_cli` to `cli_input` in [utils/README.md](https://github.com/p4lang/tutorials/compare/master...stano45:tutorials:simple-switch-cli-documentation?expand=1#diff-fe77bcb67b20e672b347e20835c80a2f5e7fdb2f76e350e2d6123fca38f73da0)
- Added a warning message to [utils/run_exercise.py](https://github.com/p4lang/tutorials/compare/master...stano45:tutorials:simple-switch-cli-documentation?expand=1#diff-215d0ea64c0cb704249e798616d9beda3a472ed6dc0392dcd6b240481da8c281) when no control file is provided (neither `runtime_json` nor `cli_input`)