### PR TITLE
Correctly labeled tokens as 'op' for operators for consistency in calc.py

### DIFF
--- a/exercises/calc/calc.py
+++ b/exercises/calc/calc.py
@@ -49,9 +49,9 @@ def op_parser(s, i, ts):
     pattern = "^\s*([-+&|^])\s*"
     match = re.match(pattern,s[i:])
     if match:
-        ts.append(Token('num', match.group(1)))
+        ts.append(Token('op', match.group(1)))
         return i + match.end(), ts
-    raise NumParseError("Expected binary operator '-', '+', '&', '|', or '^'.")
+    raise OpParseError("Expected binary operator '-', '+', '&', '|', or '^'.")
 
 
 def make_seq(p1, p2):


### PR DESCRIPTION
- Previously, the code appended the token with the `num` label (ts.append(Token('num', match.group(1)))). This would misrepresent the token, leading to confusion while differentiating between numbers and operators.
- I changed it to ts.append(Token('op', match.group(1))) to ensure that the token is properly labelled as an operator.
- Additionally, I've updated raise `NumParseError` to raise `OpParseError` to reflect the correct exception type.