### PR TITLE
Refactor the main block test cases to include tests for IPv6 encoding and decoding

### DIFF
--- a/utils/p4runtime_lib/convert.py
+++ b/utils/p4runtime_lib/convert.py
@@ -104,18 +104,29 @@ def encode(x, bitwidth):
 
 if __name__ == '__main__':
     # TODO These tests should be moved out of main eventually
+
+    # Test encoding and decoding for MAC address
     mac = "aa:bb:cc:dd:ee:ff"
     enc_mac = encodeMac(mac)
     assert(enc_mac == '\xaa\xbb\xcc\xdd\xee\xff')
     dec_mac = decodeMac(enc_mac)
     assert(mac == dec_mac)
 
-    ip = "10.0.0.1"
-    enc_ip = encodeIPv4(ip)
-    assert(enc_ip == '\x0a\x00\x00\x01')
-    dec_ip = decodeIPv4(enc_ip)
-    assert(ip == dec_ip)
+    # Test encoding and decoding for IPv4 address
+    ip0 = "10.0.0.1"
+    enc_ipv4 = encodeIPv4(ip0)
+    assert(enc_ipv4 == '\x0a\x00\x00\x01')
+    dec_ipv4 = decodeIPv4(enc_ipv4)
+    assert(ip0 == dec_ipv4)
 
+    # Test encoding and decoding for IPv6 address
+    ip1 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    enc_ipv6 = encodeIPv6(ip1)
+    assert(enc_ipv6 == '\x01\r\xb8\x85\xa3\x00\x00\x00\x00\x8a.\x03ps4')
+    dec_ipv6 = decodeIPv6(enc_ipv6)
+    assert(ip1 == dec_ipv6)
+
+    # Test encoding and decoding for a number
     num = 1337
     byte_len = 5
     enc_num = encodeNum(num, byte_len * 8)
@@ -128,6 +139,7 @@ if __name__ == '__main__':
     assert(not matchesIPv4('1000.0.0.1'))
     assert(not matchesIPv4('10001'))
 
+    # Test generic encoding function
     assert(encode(mac, 6 * 8) == enc_mac)
     assert(encode(ip, 4 * 8) == enc_ip)
     assert(encode(num, 5 * 8) == enc_num)

--- a/utils/p4runtime_lib/convert.py
+++ b/utils/p4runtime_lib/convert.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
     assert(not matchesIPv4('10001'))
 
     assert(matchesIPv6('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))
-    assert(not matchesIPv6('2001:0db8:85a3:0000:0000:8a2e:0370'))
+    assert(not matchesIPv6('241.54.113.65'))
     assert(not matchesIPv6('::1::2'))
     assert(not matchesIPv6('241.54.113.65'))
 

--- a/utils/p4runtime_lib/convert.py
+++ b/utils/p4runtime_lib/convert.py
@@ -142,7 +142,7 @@ if __name__ == '__main__':
     assert(matchesIPv6('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))
     assert(not matchesIPv6('241.54.113.65'))
     assert(not matchesIPv6('::1::2'))
-    assert(not matchesIPv6('241.54.113.65'))
+    assert(not matchesIPv6('192.168.1.1'))
 
     # Test generic encoding function
     assert(encode(mac, 6 * 8) == enc_mac)

--- a/utils/p4runtime_lib/convert.py
+++ b/utils/p4runtime_lib/convert.py
@@ -139,9 +139,15 @@ if __name__ == '__main__':
     assert(not matchesIPv4('1000.0.0.1'))
     assert(not matchesIPv4('10001'))
 
+    assert(matchesIPv6('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))
+    assert(not matchesIPv6('2001:0db8:85a3:0000:0000:8a2e:0370'))
+    assert(not matchesIPv6('2001:0db8:85a3:0000:0000:8a2e::7334'))
+    assert(not matchesIPv6('2001:0db8:85a3::8a2e:0370:7334'))
+
     # Test generic encoding function
     assert(encode(mac, 6 * 8) == enc_mac)
-    assert(encode(ip, 4 * 8) == enc_ip)
+    assert(encode(ip0, 4 * 8) == enc_ip)
+    assert(encode(ip1, 16 * 8) == enc_ipv6)
     assert(encode(num, 5 * 8) == enc_num)
     assert(encode((num,), 5 * 8) == enc_num)
     assert(encode([num], 5 * 8) == enc_num)

--- a/utils/p4runtime_lib/convert.py
+++ b/utils/p4runtime_lib/convert.py
@@ -146,7 +146,7 @@ if __name__ == '__main__':
 
     # Test generic encoding function
     assert(encode(mac, 6 * 8) == enc_mac)
-    assert(encode(ip0, 4 * 8) == enc_ip)
+    assert(encode(ip0, 4 * 8) == enc_ipv4)
     assert(encode(ip1, 16 * 8) == enc_ipv6)
     assert(encode(num, 5 * 8) == enc_num)
     assert(encode((num,), 5 * 8) == enc_num)

--- a/utils/p4runtime_lib/convert.py
+++ b/utils/p4runtime_lib/convert.py
@@ -141,8 +141,8 @@ if __name__ == '__main__':
 
     assert(matchesIPv6('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))
     assert(not matchesIPv6('2001:0db8:85a3:0000:0000:8a2e:0370'))
-    assert(not matchesIPv6('2001:0db8:85a3:0000:0000:8a2e::7334'))
-    assert(not matchesIPv6('2001:0db8:85a3::8a2e:0370:7334'))
+    assert(not matchesIPv6('::1::2'))
+    assert(not matchesIPv6('241.54.113.65'))
 
     # Test generic encoding function
     assert(encode(mac, 6 * 8) == enc_mac)


### PR DESCRIPTION
- Added comments for `MAC`, `IPv4`, and `IPv6` tests. 
- Renamed variables for `IPv4` and `IPv6` tests. 
- Refactored main block to include `IPv6` encoding and decoding tests.

Please review this linked PR, @jafingerhut.