### PR TITLE
Added ModifyTableEntry method to P4Runtime API wrapper for modifying table entries

### DIFF
--- a/utils/p4runtime_lib/switch.py
+++ b/utils/p4runtime_lib/switch.py
@@ -99,6 +99,18 @@ class SwitchConnection(object):
         else:
             self.client_stub.Write(request)
 
+    def ModifyTableEntry(self, table_entry, dry_run=False):
+        request = p4runtime_pb2.WriteRequest()
+        request.device_id = self.device_id
+        request.election_id.low = 1
+        update = request.updates.add()
+        update.type = p4runtime_pb2.Update.MODIFY
+        update.entity.table_entry.CopyFrom(table_entry)
+        if dry_run:
+            print("P4Runtime Modify: ", request)
+        else:
+            self.client_stub.Write(request)
+
     def ReadTableEntries(self, table_id=None, dry_run=False):
         request = p4runtime_pb2.ReadRequest()
         request.device_id = self.device_id


### PR DESCRIPTION
@jafingerhut , PTAL.
- Adds a method to the P4Runtime API wrapper that allows modification of table entries.
- Includes an optional parameter for previewing changes without committing them to the device.