### PR TITLE
Replace 'mn -c' with 'make stop' in READMEs

### DIFF
--- a/exercises/load_balance/README.md
+++ b/exercises/load_balance/README.md
@@ -120,11 +120,11 @@ detailed and can help pinpoint logic errors in your implementation.
 #### Cleaning up Mininet
 
 In the latter two cases above, `make` may leave a Mininet instance
-running in the background.  Use the following command to clean up
+running in the background. Use the following command to clean up
 these instances:
 
 ```bash
-mn -c
+make stop
 ```
 
 ## Next Steps

--- a/exercises/source_routing/README.md
+++ b/exercises/source_routing/README.md
@@ -136,11 +136,11 @@ There are several ways that problems might manifest:
 #### Cleaning up Mininet
 
 In the cases above, `make` may leave a Mininet instance running in
-the background.  Use the following command to clean up these
+the background. Use the following command to clean up these
 instances:
 
 ```bash
-mn -c
+make stop
 ```
 
 ## Next Steps


### PR DESCRIPTION
Just a tiny change to align these READMEs with the others.