### PR TITLE
Fix nhop_dmac in load-balance/s1-runtime.json

### DIFF
--- a/exercises/load_balance/s1-runtime.json
+++ b/exercises/load_balance/s1-runtime.json
@@ -30,7 +30,7 @@
       },
       "action_name": "MyIngress.set_nhop",
       "action_params": {
-        "nhop_dmac": "00:00:00:00:01:02",
+        "nhop_dmac": "08:00:00:00:01:02",
         "nhop_ipv4": "10.0.2.2",
         "port": 2
       }
@@ -42,7 +42,7 @@
       },
       "action_name": "MyIngress.set_nhop",
       "action_params": {
-        "nhop_dmac": "00:00:00:00:01:03",
+        "nhop_dmac": "08:00:00:00:01:03",
         "nhop_ipv4": "10.0.3.3",
         "port": 3
       }


### PR DESCRIPTION
Corrected the `nhop_dmac` fields in `s1-runtime.json`. The MAC addresses of the hosts should start with `08`, as defined in `topology.json`.

This actually didn't matter for forwarding, since the `nhop_dmac` was correct in the runtime files of s2 and s3, but still this could confuse someone examining the file.

I tested the change locally.