### PR TITLE
Updates to use the suffix 'txtpb' instead of 'txt' for P4Info files

### DIFF
--- a/exercises/basic/README.md
+++ b/exercises/basic/README.md
@@ -91,7 +91,7 @@ each switch. These are defined in the `sX-runtime.json` files, where
 **Important:** We use P4Runtime to install the control plane rules. The
 content of files `sX-runtime.json` refer to specific names of tables, keys, and
 actions, as defined in the P4Info file produced by the compiler (look for the
-file `build/basic.p4.p4info.txt` after executing `make run`). Any changes in the P4
+file `build/basic.p4.p4info.txtpb` after executing `make run`). Any changes in the P4
 program that add or rename tables, keys, or actions will need to be reflected in
 these `sX-runtime.json` files.
 

--- a/exercises/basic/pod-topo/s1-runtime.json
+++ b/exercises/basic/pod-topo/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/basic/pod-topo/s2-runtime.json
+++ b/exercises/basic/pod-topo/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/basic/pod-topo/s3-runtime.json
+++ b/exercises/basic/pod-topo/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/basic/pod-topo/s4-runtime.json
+++ b/exercises/basic/pod-topo/s4-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/basic/triangle-topo/s1-runtime.json
+++ b/exercises/basic/triangle-topo/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/basic/triangle-topo/s2-runtime.json
+++ b/exercises/basic/triangle-topo/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/basic/triangle-topo/s3-runtime.json
+++ b/exercises/basic/triangle-topo/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/basic_tunnel/s1-runtime.json
+++ b/exercises/basic_tunnel/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic_tunnel.p4.p4info.txt",
+  "p4info": "build/basic_tunnel.p4.p4info.txtpb",
   "bmv2_json": "build/basic_tunnel.json",
   "table_entries": [
     {

--- a/exercises/basic_tunnel/s2-runtime.json
+++ b/exercises/basic_tunnel/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic_tunnel.p4.p4info.txt",
+  "p4info": "build/basic_tunnel.p4.p4info.txtpb",
   "bmv2_json": "build/basic_tunnel.json",
   "table_entries": [
     {

--- a/exercises/basic_tunnel/s3-runtime.json
+++ b/exercises/basic_tunnel/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic_tunnel.p4.p4info.txt",
+  "p4info": "build/basic_tunnel.p4.p4info.txtpb",
   "bmv2_json": "build/basic_tunnel.json",
   "table_entries": [
     {

--- a/exercises/calc/s1-runtime.json
+++ b/exercises/calc/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/calc.p4.p4info.txt",
+  "p4info": "build/calc.p4.p4info.txtpb",
   "bmv2_json": "build/calc.json",
   "table_entries": []
 }

--- a/exercises/ecn/s1-runtime.json
+++ b/exercises/ecn/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/ecn.p4.p4info.txt",
+  "p4info": "build/ecn.p4.p4info.txtpb",
   "bmv2_json": "build/ecn.json",
   "table_entries": [
     {

--- a/exercises/ecn/s2-runtime.json
+++ b/exercises/ecn/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/ecn.p4.p4info.txt",
+  "p4info": "build/ecn.p4.p4info.txtpb",
   "bmv2_json": "build/ecn.json",
   "table_entries": [
     {

--- a/exercises/ecn/s3-runtime.json
+++ b/exercises/ecn/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/ecn.p4.p4info.txt",
+  "p4info": "build/ecn.p4.p4info.txtpb",
   "bmv2_json": "build/ecn.json",
   "table_entries": [
     {

--- a/exercises/firewall/README.md
+++ b/exercises/firewall/README.md
@@ -107,7 +107,7 @@ each switch. These are defined in the `sX-runtime.json` files, where
 **Important:** We use P4Runtime to install the control plane rules. The
 content of files `sX-runtime.json` refer to specific names of tables, keys, and
 actions, as defined in the P4Info file produced by the compiler (look for the
-file `build/firewall.p4.p4info.txt` after executing `make run`). Any changes in the P4
+file `build/firewall.p4.p4info.txtpb` after executing `make run`). Any changes in the P4
 program that add or rename tables, keys, or actions will need to be reflected in
 these `sX-runtime.json` files.
 

--- a/exercises/firewall/pod-topo/s1-runtime.json
+++ b/exercises/firewall/pod-topo/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/firewall.p4.p4info.txt",
+  "p4info": "build/firewall.p4.p4info.txtpb",
   "bmv2_json": "build/firewall.json",
   "table_entries": [
     {

--- a/exercises/firewall/pod-topo/s2-runtime.json
+++ b/exercises/firewall/pod-topo/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/firewall/pod-topo/s3-runtime.json
+++ b/exercises/firewall/pod-topo/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/firewall/pod-topo/s4-runtime.json
+++ b/exercises/firewall/pod-topo/s4-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {

--- a/exercises/link_monitor/README.md
+++ b/exercises/link_monitor/README.md
@@ -137,7 +137,7 @@ each switch. These are defined in the `sX-runtime.json` files, where
 **Important:** We use P4Runtime to install the control plane rules. The
 content of files `sX-runtime.json` refer to specific names of tables, keys, and
 actions, as defined in the P4Info file produced by the compiler (look for the
-file `build/link_monitor.p4.p4info.txt` after executing `make run`). Any
+file `build/link_monitor.p4.p4info.txtpb` after executing `make run`). Any
 changes in the P4 program that add or rename tables, keys, or actions
 will need to be reflected in these `sX-runtime.json` files.
 

--- a/exercises/link_monitor/pod-topo/s1-runtime.json
+++ b/exercises/link_monitor/pod-topo/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/link_monitor.p4.p4info.txt",
+  "p4info": "build/link_monitor.p4.p4info.txtpb",
   "bmv2_json": "build/link_monitor.json",
   "table_entries": [
     {

--- a/exercises/link_monitor/pod-topo/s2-runtime.json
+++ b/exercises/link_monitor/pod-topo/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/link_monitor.p4.p4info.txt",
+  "p4info": "build/link_monitor.p4.p4info.txtpb",
   "bmv2_json": "build/link_monitor.json",
   "table_entries": [
     {

--- a/exercises/link_monitor/pod-topo/s3-runtime.json
+++ b/exercises/link_monitor/pod-topo/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/link_monitor.p4.p4info.txt",
+  "p4info": "build/link_monitor.p4.p4info.txtpb",
   "bmv2_json": "build/link_monitor.json",
   "table_entries": [
     {

--- a/exercises/link_monitor/pod-topo/s4-runtime.json
+++ b/exercises/link_monitor/pod-topo/s4-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/link_monitor.p4.p4info.txt",
+  "p4info": "build/link_monitor.p4.p4info.txtpb",
   "bmv2_json": "build/link_monitor.json",
   "table_entries": [
     {

--- a/exercises/load_balance/s1-runtime.json
+++ b/exercises/load_balance/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/load_balance.p4.p4info.txt",
+  "p4info": "build/load_balance.p4.p4info.txtpb",
   "bmv2_json": "build/load_balance.json",
   "table_entries": [
     {

--- a/exercises/load_balance/s2-runtime.json
+++ b/exercises/load_balance/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/load_balance.p4.p4info.txt",
+  "p4info": "build/load_balance.p4.p4info.txtpb",
   "bmv2_json": "build/load_balance.json",
   "table_entries": [
     {

--- a/exercises/load_balance/s3-runtime.json
+++ b/exercises/load_balance/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/load_balance.p4.p4info.txt",
+  "p4info": "build/load_balance.p4.p4info.txtpb",
   "bmv2_json": "build/load_balance.json",
   "table_entries": [
     {

--- a/exercises/mri/s1-runtime.json
+++ b/exercises/mri/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/mri.p4.p4info.txt",
+  "p4info": "build/mri.p4.p4info.txtpb",
   "bmv2_json": "build/mri.json",
   "table_entries": [
     {

--- a/exercises/mri/s2-runtime.json
+++ b/exercises/mri/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/mri.p4.p4info.txt",
+  "p4info": "build/mri.p4.p4info.txtpb",
   "bmv2_json": "build/mri.json",
   "table_entries": [
     {

--- a/exercises/mri/s3-runtime.json
+++ b/exercises/mri/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/mri.p4.p4info.txt",
+  "p4info": "build/mri.p4.p4info.txtpb",
   "bmv2_json": "build/mri.json",
   "table_entries": [
     {

--- a/exercises/multicast/README.md
+++ b/exercises/multicast/README.md
@@ -88,7 +88,7 @@ packet-processing rules in the tables of each switch. These are defined in the
 **Important:** We use P4Runtime to install the control plane rules. The
 content of files `sX-runtime.json` refer to specific names of tables, keys, and
 actions, as defined in the P4Info file produced by the compiler (look for the
-file `build/basic.p4.p4info.txt` after executing `make run`). Any changes in the P4
+file `build/basic.p4.p4info.txtpb` after executing `make run`). Any changes in the P4
 program that add or rename tables, keys, or actions will need to be reflected in
 these `sX-runtime.json` files.
 

--- a/exercises/multicast/sig-topo/s1-runtime.json
+++ b/exercises/multicast/sig-topo/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/multicast.p4.p4info.txt",
+  "p4info": "build/multicast.p4.p4info.txtpb",
   "bmv2_json": "build/multicast.json",
   "table_entries": [
     {

--- a/exercises/multicast/solution/s1-runtime.json
+++ b/exercises/multicast/solution/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/multicast.p4.p4info.txt",
+  "p4info": "build/multicast.p4.p4info.txtpb",
   "bmv2_json": "build/multicast.json",
   "table_entries": [
     {

--- a/exercises/p4runtime/mycontroller.py
+++ b/exercises/p4runtime/mycontroller.py
@@ -191,7 +191,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='P4Runtime Controller')
     parser.add_argument('--p4info', help='p4info proto in text format from p4c',
                         type=str, action="store", required=False,
-                        default='./build/advanced_tunnel.p4.p4info.txt')
+                        default='./build/advanced_tunnel.p4.p4info.txtpb')
     parser.add_argument('--bmv2-json', help='BMv2 JSON file from p4c',
                         type=str, action="store", required=False,
                         default='./build/advanced_tunnel.json')

--- a/exercises/p4runtime/solution/mycontroller.py
+++ b/exercises/p4runtime/solution/mycontroller.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='P4Runtime Controller')
     parser.add_argument('--p4info', help='p4info proto in text format from p4c',
                         type=str, action="store", required=False,
-                        default='./build/advanced_tunnel.p4.p4info.txt')
+                        default='./build/advanced_tunnel.p4.p4info.txtpb')
     parser.add_argument('--bmv2-json', help='BMv2 JSON file from p4c',
                         type=str, action="store", required=False,
                         default='./build/advanced_tunnel.json')

--- a/exercises/qos/s1-runtime.json
+++ b/exercises/qos/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/qos.p4.p4info.txt",
+  "p4info": "build/qos.p4.p4info.txtpb",
   "bmv2_json": "build/qos.json",
   "table_entries": [
     {

--- a/exercises/qos/s2-runtime.json
+++ b/exercises/qos/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/qos.p4.p4info.txt",
+  "p4info": "build/qos.p4.p4info.txtpb",
   "bmv2_json": "build/qos.json",
   "table_entries": [
     {

--- a/exercises/qos/s3-runtime.json
+++ b/exercises/qos/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/qos.p4.p4info.txt",
+  "p4info": "build/qos.p4.p4info.txtpb",
   "bmv2_json": "build/qos.json",
   "table_entries": [
     {

--- a/exercises/source_routing/s1-runtime.json
+++ b/exercises/source_routing/s1-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/source_routing.p4.p4info.txt",
+  "p4info": "build/source_routing.p4.p4info.txtpb",
   "bmv2_json": "build/source_routing.json",
   "table_entries": []
 }

--- a/exercises/source_routing/s2-runtime.json
+++ b/exercises/source_routing/s2-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/source_routing.p4.p4info.txt",
+  "p4info": "build/source_routing.p4.p4info.txtpb",
   "bmv2_json": "build/source_routing.json",
   "table_entries": []
 }

--- a/exercises/source_routing/s3-runtime.json
+++ b/exercises/source_routing/s3-runtime.json
@@ -1,6 +1,6 @@
 {
   "target": "bmv2",
-  "p4info": "build/source_routing.p4.p4info.txt",
+  "p4info": "build/source_routing.p4.p4info.txtpb",
   "bmv2_json": "build/source_routing.json",
   "table_entries": []
 }

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -3,7 +3,7 @@ PCAP_DIR = pcaps
 LOG_DIR = logs
 
 P4C = p4c-bm2-ss
-P4C_ARGS += --p4runtime-files $(BUILD_DIR)/$(basename $@).p4.p4info.txt
+P4C_ARGS += --p4runtime-files $(BUILD_DIR)/$(basename $@).p4.p4info.txtpb
 
 RUN_SCRIPT = ../../utils/run_exercise.py
 
@@ -32,10 +32,10 @@ endif
 all: run
 
 run: build
-	sudo python3 $(RUN_SCRIPT) -t $(TOPO) $(run_args)
+	sudo PATH=$(PATH) ${P4GUIDE_SUDO_OPTS} python3 $(RUN_SCRIPT) -t $(TOPO) $(run_args)
 
 stop:
-	sudo mn -c
+	sudo PATH=$(PATH) `which mn` -c
 
 build: dirs $(compiled_json)
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -96,7 +96,7 @@ In the example, since there is only one table in the data-plane counterpart, all
 ```json
 {
   "target": "bmv2",
-  "p4info": "build/basic.p4.p4info.txt",
+  "p4info": "build/basic.p4.p4info.txtpb",
   "bmv2_json": "build/basic.json",
   "table_entries": [
     {


### PR DESCRIPTION
p4c has had a warning about 'txt' being deprecated in favor of 'txtpb' since 2024-Jan.