### PR TITLE
made the vagrant bootstrap script non-interactive.  This fixes a prob…

### DIFF
--- a/vm-ubuntu-24.04/root-bootstrap.sh
+++ b/vm-ubuntu-24.04/root-bootstrap.sh
@@ -18,6 +18,8 @@
 # Print commands and exit on errors
 set -xe
 
+export DEBIAN_FRONTEND=noninteractive
+
 apt-get update
 apt-get -y upgrade
 apt-get install -y \


### PR DESCRIPTION
…lem during Vagrant set up of Ubuntu where it gets stuck on installing grub-2, because there is no human input.  Without this fix, one needs to ctrl-c out of the vagrant ubuntu install, do 'vagrant ssh' into the vm, do some dpkg stuff selecting the right options for grub-2, before it succeeds.  This is discouraging for new comers to vagrant and linux.